### PR TITLE
chore: 디자인 토큰 이식 및 cn 유틸 추가 (#3)

### DIFF
--- a/.claude/skills/epigram-mobile-design-system/SKILL.md
+++ b/.claude/skills/epigram-mobile-design-system/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: epigram-mobile-design-system
+description: Use this skill when styling or building any UI component, screen, or layout for the Epigram mobile app (React Native + Expo + NativeWind). Contains design tokens (colors, typography, spacing, radius), component specs with Props signatures matching the web project, and mobile-native UX patterns (touch targets, gestures, bottom sheets). Reference this whenever implementing screens, components, or applying styles.
+---
+
+# Epigram Mobile Design System
+
+Epigram 웹 프로젝트(Next.js 15 + Tailwind v4)에서 추출한 디자인 토큰과 컴포넌트 스펙을, React Native + Expo SDK 54 + NativeWind v4 + Tailwind 3.4 환경에 맞게 변환한 자기완결적 디자인 시스템이다.
+
+## 언제 이 스킬을 쓰는가
+
+- 새 화면을 만들거나 기존 화면을 수정할 때
+- shared/ui 컴포넌트를 구현할 때 (Button, Input, Modal 등)
+- 색·타입·간격·라디우스 같은 디자인 토큰을 적용할 때
+- 모바일 UX 패턴(바텀시트, Pull-to-refresh, 터치 영역 등)을 적용할 때
+
+## 파일 구성
+
+| 파일 | 용도 |
+|---|---|
+| `SKILL.md` | 이 파일 — 전체 개요와 사용 순서 |
+| `tokens.ts` | `tailwind.config.js`의 `theme.extend`에 바로 spread할 수 있는 NativeWind 토큰 |
+| `tokens.json` | 순수 데이터(JSON). 비개발 도구나 다른 자동화에서 참고용 |
+| `components.md` | shared/ui 컴포넌트 변환 스펙 (Props + variant + NativeWind 클래스 예시) |
+| `patterns.md` | 모바일 UX 패턴 (터치 영역, 제스처, 바텀시트, 네비게이션, 애니메이션) |
+
+## 사용 순서 (Claude Code가 UI 작업 시작 시)
+
+1. **`tokens.ts` 먼저 읽고** 프로젝트 `tailwind.config.js`에 병합한다.
+   ```ts
+   // tailwind.config.js
+   import { colors, fontSize, spacing, borderRadius, fontFamily } from "./src/shared/config/tokens";
+   module.exports = {
+     content: ["./app/**/*.{ts,tsx}", "./src/**/*.{ts,tsx}"],
+     presets: [require("nativewind/preset")],
+     theme: {
+       extend: { colors, fontSize, spacing, borderRadius, fontFamily },
+     },
+   };
+   ```
+2. **`components.md`에서 필요한 컴포넌트 스펙을 확인**하고 `src/shared/ui/`에 구현한다.
+3. **`patterns.md`를 참고**해서 터치 영역(44pt)·바텀시트·Pull-to-refresh 등 네이티브 패턴을 적용한다.
+4. 웹 프로젝트의 Props 시그니처·네이밍 컨벤션(`is/has/can`, `handle` 접두사)을 그대로 유지한다.
+
+## 헌법(Constitution) 준수 요약
+
+- **네이밍**: 불리언은 `is/has/can`, 이벤트 핸들러는 `handle` 접두사
+- **타입**: Props는 `interface`로 정의, `any` 금지
+- **중첩 깊이**: 최대 2단계 (초과 시 헬퍼 함수로 추출)
+- **컴포넌트**: `function` 키워드 선언(화살표 금지), 명시적 반환 타입 `ReactElement`
+- **아이콘**: `lucide-react-native`만 사용. SVG 인라인·이미지 파일 아이콘 금지
+- **폼**: React Hook Form + Zod
+- **접근성**: `accessible`, `accessibilityRole`, `accessibilityLabel` 명시. 터치 타겟 최소 44×44pt
+
+## 웹 → 모바일 변환 요약
+
+| 웹 | 모바일 |
+|---|---|
+| `hover:` | `active:` (Pressed) — NativeWind v4 지원 |
+| `cursor: pointer` | `Pressable` 컴포넌트로 감싸기 |
+| `<button>` | `Pressable` + `Text` |
+| Dropdown / Select | BottomSheet (`@gorhom/bottom-sheet`) |
+| 풀스크린 Modal | BottomSheet 또는 `Modal` (`presentationStyle="pageSheet"`) |
+| 목록 | `FlatList` + Pull-to-refresh + Infinite scroll |
+| `lucide-react` | `lucide-react-native` (API 동일) |
+| `next/image` | `expo-image` 또는 `Image` |
+| `next/link` | `Link` from `expo-router` |
+
+## 웹 프로젝트 원본 토큰 경로
+
+- 원본 CSS: `src/app/globals.css` (Tailwind v4 `@theme` 블록)
+- 원본 컴포넌트: `src/shared/ui/*.tsx`
+- 원본 헌법: `.specify/memory/constitution.md`

--- a/.claude/skills/epigram-mobile-design-system/components.md
+++ b/.claude/skills/epigram-mobile-design-system/components.md
@@ -1,0 +1,897 @@
+# Epigram Mobile Components
+
+Epigram 웹(`src/shared/ui/*`)의 컴포넌트를 React Native + NativeWind v4로 변환한 스펙.
+각 컴포넌트는 `웹 Props 시그니처를 최대한 유지`하되, 모바일 네이티브 패턴에 맞춰 조정했다.
+
+**공통 규칙** (모든 컴포넌트에 적용 — 헌법 준수):
+- `function` 키워드로 선언 (화살표 함수 금지)
+- Props는 `interface`로 정의, 반환 타입은 `ReactElement`
+- 불리언 prop은 `is/has/can` 접두사, 이벤트는 `handle` 접두사
+- `any` 금지, 중첩 깊이 2단계 초과 시 헬퍼 추출
+- 아이콘은 `lucide-react-native`만 사용
+- 터치 타겟 최소 `44×44pt` (Button, IconButton 등 `hitSlop`이나 패딩으로 확보)
+
+---
+
+## Button
+
+웹 원본: `src/shared/ui/Button.tsx`
+
+### 언제 쓰는가
+
+- 폼 제출 (로그인·회원가입·에피그램 작성)
+- 모달 확인/취소
+- 목록 "더보기" · 빈 상태의 CTA
+
+### Variants
+
+| variant | 용도 | 스타일 요약 |
+|---|---|---|
+| `primary` | 주요 액션 (제출·확인) | `bg-black-500`, `text-white` |
+| `secondary` | 보조 액션 (취소·뒤로) | `border-black-500`, `text-black-500` |
+| `ghost` | 인라인 텍스트 버튼 | `text-blue-400` |
+
+### Props
+
+```ts
+interface ButtonProps extends PressableProps {
+  variant?: "primary" | "secondary" | "ghost";
+  isLoading?: boolean;
+  children: ReactNode;
+}
+```
+
+### 구현 예시
+
+```tsx
+import { Pressable, Text, ActivityIndicator } from "react-native";
+import type { PressableProps } from "react-native";
+import type { ReactElement, ReactNode } from "react";
+
+import { cn } from "@/shared/lib/cn";
+
+interface ButtonProps extends PressableProps {
+  variant?: "primary" | "secondary" | "ghost";
+  isLoading?: boolean;
+  children: ReactNode;
+}
+
+const VARIANT_CLASSES = {
+  primary: "bg-black-500 active:bg-black-600 disabled:bg-blue-300",
+  secondary: "border border-black-500 active:bg-blue-200 disabled:border-blue-300",
+  ghost: "active:opacity-60",
+} as const;
+
+const TEXT_CLASSES = {
+  primary: "text-white",
+  secondary: "text-black-500",
+  ghost: "text-blue-400",
+} as const;
+
+export function Button({
+  variant = "primary",
+  isLoading = false,
+  disabled,
+  children,
+  className,
+  ...props
+}: ButtonProps): ReactElement {
+  return (
+    <Pressable
+      disabled={disabled || isLoading}
+      accessibilityRole="button"
+      className={cn(
+        "min-h-[44px] flex-row items-center justify-center rounded-lg px-4 py-2",
+        VARIANT_CLASSES[variant],
+        className
+      )}
+      {...props}
+    >
+      {isLoading ? <ActivityIndicator size="small" className="mr-2" /> : null}
+      <Text className={cn("text-sm font-semibold", TEXT_CLASSES[variant])}>
+        {children}
+      </Text>
+    </Pressable>
+  );
+}
+```
+
+### 모바일 변환 포인트
+
+- 웹 `hover:bg-black-600` → `active:bg-black-600` (NativeWind v4 `active:` prefix 사용)
+- 웹 `active:scale-95` → iOS는 자연스러운 opacity 피드백(opacity 0.7)이 더 네이티브다. 강조 시에만 `active:scale-95` 유지.
+- `min-h-[44px]`로 터치 타겟 확보
+
+---
+
+## Input
+
+웹 원본: `src/shared/ui/Input.tsx`
+
+### 언제 쓰는가
+
+- 이메일·비밀번호·닉네임 등 한 줄 입력
+
+### Props
+
+```ts
+interface InputProps extends TextInputProps {
+  label?: string;
+  error?: string;
+}
+```
+
+### 구현 예시
+
+```tsx
+import { View, Text, TextInput } from "react-native";
+import type { TextInputProps } from "react-native";
+import type { ReactElement } from "react";
+
+import { cn } from "@/shared/lib/cn";
+
+interface InputProps extends TextInputProps {
+  label?: string;
+  error?: string;
+}
+
+export function Input({ label, error, className, ...props }: InputProps): ReactElement {
+  const hasError = Boolean(error);
+
+  return (
+    <View className="flex flex-col gap-2">
+      {label ? (
+        <Text className="text-sm font-medium text-blue-900">{label}</Text>
+      ) : null}
+      <TextInput
+        placeholderTextColor="#abb8ce" // blue-400
+        accessibilityLabel={label}
+        className={cn(
+          "h-11 w-full rounded-lg bg-blue-200 px-4 text-sm text-black-950",
+          "focus:bg-white", // NativeWind v4 focus:
+          hasError && "bg-white border-2 border-error",
+          className
+        )}
+        {...props}
+      />
+      {error ? (
+        <Text className="text-xs text-error">{error}</Text>
+      ) : null}
+    </View>
+  );
+}
+```
+
+### 모바일 변환 포인트
+
+- 웹 `placeholder:text-blue-400` → RN `placeholderTextColor` prop으로 전달 (NativeWind 불가)
+- 웹 `focus:ring-2 focus:ring-black-500` → RN은 ring 미지원. `focus:border-2 focus:border-black-500`으로 대체
+- `secureTextEntry`, `keyboardType`, `autoCapitalize="none"` 등 RN 전용 props 활용
+
+---
+
+## Textarea
+
+웹 원본: `src/shared/ui/Textarea.tsx`
+
+### 언제 쓰는가
+
+- 에피그램 본문 입력, 댓글 입력
+
+### Props
+
+```ts
+interface TextareaProps extends TextInputProps {
+  label?: string;
+  error?: string;
+  minRows?: number;
+}
+```
+
+### 구현 예시
+
+```tsx
+import { View, Text, TextInput } from "react-native";
+import type { TextInputProps } from "react-native";
+
+interface TextareaProps extends TextInputProps {
+  label?: string;
+  error?: string;
+  minRows?: number;
+}
+
+export function Textarea({
+  label,
+  error,
+  minRows = 4,
+  className,
+  ...props
+}: TextareaProps): ReactElement {
+  return (
+    <View className="flex flex-col gap-2">
+      {label ? (
+        <Text className="text-sm font-medium text-blue-900">{label}</Text>
+      ) : null}
+      <TextInput
+        multiline
+        textAlignVertical="top"
+        numberOfLines={minRows}
+        placeholderTextColor="#abb8ce"
+        className={cn(
+          "w-full rounded-lg bg-blue-200 px-4 py-3 text-sm text-black-950",
+          `min-h-[${minRows * 24}px]`,
+          error && "bg-white border-2 border-error",
+          className
+        )}
+        {...props}
+      />
+      {error ? <Text className="text-xs text-error">{error}</Text> : null}
+    </View>
+  );
+}
+```
+
+### 모바일 변환 포인트
+
+- `multiline`, `textAlignVertical="top"` 필수 (Android에서 텍스트가 가운데 정렬되는 것 방지)
+- `returnKeyType="default"`로 줄바꿈 허용
+
+---
+
+## Tag / Chip
+
+웹 원본: `src/shared/ui/Tag.tsx`
+
+### 언제 쓰는가
+
+- 에피그램에 붙는 해시태그
+- 최근 검색어 chip
+- 카테고리 필터
+
+### Props
+
+```ts
+interface TagProps {
+  label: string;
+  onPress?: (label: string) => void;
+}
+```
+
+### 구현 예시
+
+```tsx
+import { Pressable, Text } from "react-native";
+
+interface TagProps {
+  label: string;
+  onPress?: (label: string) => void;
+}
+
+export function Tag({ label, onPress }: TagProps): ReactElement {
+  const baseClass =
+    "flex-row items-center rounded-full bg-blue-200 px-3 py-1.5";
+
+  if (!onPress) {
+    return (
+      <View className={baseClass}>
+        <Text className="text-sm font-medium text-blue-600">#{label}</Text>
+      </View>
+    );
+  }
+
+  return (
+    <Pressable
+      onPress={() => onPress(label)}
+      accessibilityRole="button"
+      accessibilityLabel={`태그 ${label}`}
+      className={cn(baseClass, "active:bg-blue-300")}
+      hitSlop={8}
+    >
+      <Text className="text-sm font-medium text-blue-600">#{label}</Text>
+    </Pressable>
+  );
+}
+```
+
+### 모바일 변환 포인트
+
+- 웹 `onClick` → RN `onPress`로 네이밍 변경 (프로젝트 컨벤션에 따라 `handleTagPress` 같은 형태)
+- `hitSlop`으로 실질 터치 영역 확대
+
+---
+
+## Modal
+
+웹 원본: `src/shared/ui/Modal.tsx`
+
+### 언제 쓰는가
+
+- 확인/취소가 필요한 다이얼로그 (`ConfirmModal`)
+- 프로필·상세 정보 팝업
+
+### Props
+
+```ts
+interface ModalProps {
+  isVisible: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+interface ConfirmModalProps {
+  isVisible: boolean;
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+```
+
+### 구현 예시
+
+```tsx
+import { Modal as RNModal, View, Text, Pressable } from "react-native";
+
+interface ModalProps {
+  isVisible: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export function Modal({ isVisible, onClose, children }: ModalProps): ReactElement {
+  return (
+    <RNModal
+      visible={isVisible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+      statusBarTranslucent
+    >
+      <Pressable
+        onPress={onClose}
+        accessible={false}
+        className="flex-1 items-center justify-center bg-black/50 px-6"
+      >
+        <Pressable
+          accessibilityRole="none"
+          className="w-full max-w-md rounded-2xl bg-white p-6"
+          // 자식 터치가 배경으로 전파되지 않도록 Pressable로 감쌈
+        >
+          {children}
+        </Pressable>
+      </Pressable>
+    </RNModal>
+  );
+}
+```
+
+### 모바일 변환 포인트
+
+- 웹 backdrop click → RN은 바깥 `Pressable`로 처리
+- `onRequestClose`는 Android 뒤로가기 버튼 대응 (필수)
+- 긴 콘텐츠나 선택지가 많으면 → `BottomSheet` 사용 권장 (patterns.md 참고)
+
+---
+
+## BottomSheet
+
+웹에는 없음 — 모바일 전용. 드롭다운·액션시트·긴 콘텐츠 선택 UI를 대체한다.
+
+### 언제 쓰는가
+
+- 정렬 옵션 선택, 필터
+- 공유·삭제 등 컨텍스트 액션 시트
+- 에피그램 상세의 감정 선택
+
+### 추천 라이브러리
+
+`@gorhom/bottom-sheet` (제스처·스냅 포인트 지원)
+
+### Props
+
+```ts
+interface BottomSheetProps {
+  isVisible: boolean;
+  onClose: () => void;
+  snapPoints?: string[]; // e.g. ["40%", "80%"]
+  children: ReactNode;
+}
+```
+
+### 구현 예시 (간이 — Modal + 슬라이드 애니메이션)
+
+```tsx
+import { Modal, View, Pressable, Animated } from "react-native";
+
+export function BottomSheet({
+  isVisible,
+  onClose,
+  children,
+}: BottomSheetProps): ReactElement {
+  return (
+    <Modal
+      visible={isVisible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+      statusBarTranslucent
+    >
+      <Pressable
+        onPress={onClose}
+        className="flex-1 justify-end bg-black/50"
+      >
+        <Pressable className="rounded-t-2xl bg-white px-6 pt-6 pb-10">
+          {/* 드래그 핸들 (시각적 힌트) */}
+          <View className="mx-auto mb-4 h-1 w-10 rounded-full bg-gray-200" />
+          {children}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+```
+
+---
+
+## Toast
+
+웹에는 명시된 컴포넌트 없음. 모바일은 성공/에러 피드백이 필수.
+
+### 언제 쓰는가
+
+- 에피그램 생성·수정·삭제 성공 피드백
+- API 에러 전역 알림
+- 좋아요 토글 같은 짧은 피드백
+
+### 추천 라이브러리
+
+`react-native-toast-message` 또는 `sonner-native`
+
+### 디자인 스펙
+
+- 위치: 상단 또는 하단 (Safe Area 고려)
+- 배경:
+  - success → `bg-illust-green` + `text-white`
+  - error → `bg-error` + `text-white`
+  - info → `bg-black-700` + `text-white`
+- `rounded-xl`, `px-4 py-3`, `text-sm font-medium`
+- 자동 닫힘 2.5초
+
+---
+
+## Skeleton
+
+웹은 `animate-pulse` + `bg-blue-200` 조합(`EpigramFeed`의 `h-28 animate-pulse rounded-2xl bg-blue-200`).
+
+### 언제 쓰는가
+
+- 초기 로딩 시 카드·리스트 플레이스홀더
+- 프로필·통계 등 개별 데이터 로드 중
+
+### Props
+
+```ts
+interface SkeletonProps {
+  width?: number | string;
+  height?: number | string;
+  className?: string;
+}
+```
+
+### 구현 예시
+
+```tsx
+import { View } from "react-native";
+import { useEffect, useRef } from "react";
+import { Animated, Easing } from "react-native";
+
+export function Skeleton({
+  width = "100%",
+  height = 16,
+  className,
+}: SkeletonProps): ReactElement {
+  const opacity = useRef(new Animated.Value(0.4)).current;
+
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, {
+          toValue: 1,
+          duration: 800,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: 0.4,
+          duration: 800,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+      ])
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [opacity]);
+
+  return (
+    <Animated.View
+      style={{ width, height, opacity }}
+      className={cn("rounded-lg bg-blue-200", className)}
+    />
+  );
+}
+```
+
+---
+
+## Avatar
+
+웹의 유저 프로필 아이콘 자리. 원본은 `next/image` + `<User />` fallback.
+
+### Props
+
+```ts
+interface AvatarProps {
+  imageUrl?: string | null;
+  nickname: string;
+  size?: 24 | 32 | 48 | 64;
+}
+```
+
+### 구현 예시
+
+```tsx
+import { Image, View } from "react-native";
+import { User } from "lucide-react-native";
+
+export function Avatar({ imageUrl, nickname, size = 32 }: AvatarProps): ReactElement {
+  if (imageUrl) {
+    return (
+      <Image
+        source={{ uri: imageUrl }}
+        accessibilityLabel={`${nickname} 프로필`}
+        style={{ width: size, height: size }}
+        className="rounded-full bg-blue-200"
+      />
+    );
+  }
+
+  return (
+    <View
+      style={{ width: size, height: size }}
+      className="items-center justify-center rounded-full bg-blue-200"
+    >
+      <User size={size * 0.6} color="#ababab" />
+    </View>
+  );
+}
+```
+
+---
+
+## Header (화면별 네이티브 헤더)
+
+웹 원본: `src/widgets/header/ui/Header.tsx` (전역 헤더).
+모바일에서는 **Expo Router의 화면 옵션**으로 제어하는 게 일반적.
+
+### 구현 방식
+
+```tsx
+// app/(tabs)/feeds.tsx
+import { Stack } from "expo-router";
+
+export default function FeedsScreen(): ReactElement {
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          title: "피드",
+          headerTitleStyle: {
+            fontFamily: "NanumMyeongjo-Bold",
+            fontSize: 20,
+            color: "#1a212d", // blue-950
+          },
+          headerStyle: { backgroundColor: "rgba(255,255,255,0.95)" },
+          headerShadowVisible: false,
+        }}
+      />
+      {/* ... */}
+    </>
+  );
+}
+```
+
+### 스펙
+
+- 높이: 52pt (모바일 웹과 동일)
+- 배경: `bg-white/95` + 아래 `border-b border-line-100`
+- 로고(Epigram): 랜딩·탭 루트에서만 표시. 나머지는 화면 타이틀 + 뒤로가기
+
+---
+
+## BottomTabBar
+
+웹에는 없음 — 모바일 네이티브 전용. Expo Router의 Tabs 레이아웃으로 구현.
+
+### 탭 구성 (웹의 네비게이션 + 추가 화면 기준)
+
+| 탭 | 라우트 | 아이콘 (lucide-react-native) |
+|---|---|---|
+| 피드 | `/(tabs)/feeds` | `Home` |
+| 검색 | `/(tabs)/search` | `Search` |
+| 작성 | `/(tabs)/addepigram` | `PlusCircle` |
+| 마이 | `/(tabs)/mypage` | `User` |
+
+### 구현 예시
+
+```tsx
+// app/(tabs)/_layout.tsx
+import { Tabs } from "expo-router";
+import { Home, Search, PlusCircle, User } from "lucide-react-native";
+
+export default function TabLayout(): ReactElement {
+  return (
+    <Tabs
+      screenOptions={{
+        tabBarActiveTintColor: "#52698e", // blue-700
+        tabBarInactiveTintColor: "#abb8ce", // blue-400
+        tabBarStyle: {
+          height: 56,
+          borderTopColor: "#f2f2f2", // line-100
+          backgroundColor: "#ffffff",
+        },
+        tabBarLabelStyle: {
+          fontFamily: "Pretendard",
+          fontSize: 11,
+          fontWeight: "600",
+        },
+      }}
+    >
+      <Tabs.Screen
+        name="feeds"
+        options={{
+          title: "피드",
+          tabBarIcon: ({ color, size }) => <Home color={color} size={size} />,
+        }}
+      />
+      {/* 나머지 탭 동일 패턴 */}
+    </Tabs>
+  );
+}
+```
+
+---
+
+## IconButton
+
+### 언제 쓰는가
+
+- 헤더 우측 액션 (공유·삭제)
+- 카드 내부 좋아요·북마크 버튼
+- 인풋 초기화 X 버튼
+
+### Props
+
+```ts
+interface IconButtonProps {
+  icon: LucideIcon;
+  label: string; // accessibility용 (시각적 미표시)
+  onPress: () => void;
+  size?: number;
+  variant?: "default" | "ghost";
+  disabled?: boolean;
+}
+```
+
+### 구현 예시
+
+```tsx
+import { Pressable } from "react-native";
+import type { LucideIcon } from "lucide-react-native";
+
+export function IconButton({
+  icon: Icon,
+  label,
+  onPress,
+  size = 24,
+  variant = "default",
+  disabled,
+}: IconButtonProps): ReactElement {
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      hitSlop={8}
+      className={cn(
+        "min-h-[44px] min-w-[44px] items-center justify-center rounded-full",
+        variant === "default" && "active:bg-blue-200",
+        variant === "ghost" && "active:opacity-60",
+        disabled && "opacity-40"
+      )}
+    >
+      <Icon size={size} color="#454545" />
+    </Pressable>
+  );
+}
+```
+
+---
+
+## EpigramCard
+
+웹 원본: `src/entities/epigram/ui/EpigramListCard.tsx`.
+모바일의 핵심 콘텐츠 블록 — 에피그램 한 편을 카드로 표시.
+
+### Props
+
+```ts
+interface EpigramCardProps {
+  epigram: Epigram; // entities/epigram/model/schema의 타입
+  onPress?: (id: number) => void;
+}
+```
+
+### 시각적 스펙
+
+- 배경: `bg-white`
+- 테두리: `border border-line-100`
+- 라디우스: `rounded-xl` (16px)
+- 패딩: `p-6`
+- 섀도: `shadow-card` (토큰 참고)
+- 본문: `font-serif text-epigram-base text-black-600` (18/30)
+- 저자: `font-serif text-base text-blue-400` (오른쪽 정렬, `- 이름 -` 포맷)
+- 태그: 하단, 오른쪽 정렬, `font-serif text-sm text-blue-400` (`#tag` 텍스트 형태)
+- **Decorative ruled lines** (옵션 — 웹 원본 디테일):
+  - `repeating-linear-gradient`로 24px 간격의 옅은 가로선. RN에서는 `react-native-svg`의 `<Pattern>`이나 24px 간격 `<View>` 반복으로 구현 가능. 없어도 무방.
+
+### 구현 예시 (간소화)
+
+```tsx
+import { View, Text, Pressable } from "react-native";
+
+export function EpigramCard({ epigram, onPress }: EpigramCardProps): ReactElement {
+  return (
+    <Pressable
+      onPress={() => onPress?.(epigram.id)}
+      accessibilityRole="button"
+      accessibilityLabel={`${epigram.author}의 에피그램`}
+      className="overflow-hidden rounded-xl border border-line-100 bg-white p-6 active:opacity-80"
+      style={{
+        shadowColor: "#000",
+        shadowOpacity: 0.04,
+        shadowRadius: 12,
+        shadowOffset: { width: 0, height: 3 },
+        elevation: 2,
+      }}
+    >
+      <View className="gap-5">
+        <Text className="font-serif text-epigram-base text-black-600">
+          {epigram.content}
+        </Text>
+        <Text className="text-right font-serif text-base text-blue-400">
+          - {epigram.author} -
+        </Text>
+      </View>
+
+      {epigram.tags.length > 0 ? (
+        <View className="mt-3 flex-row flex-wrap justify-end gap-3">
+          {epigram.tags.map((tag) => (
+            <Text key={tag.id} className="font-serif text-sm text-blue-400">
+              #{tag.name}
+            </Text>
+          ))}
+        </View>
+      ) : null}
+    </Pressable>
+  );
+}
+```
+
+---
+
+## EmptyState
+
+웹 원본: `src/shared/ui/EmptyState.tsx`.
+
+### 언제 쓰는가
+
+- 검색 결과 없음, 피드 비어있음, 댓글 없음 등
+
+### Props
+
+```ts
+interface EmptyStateProps {
+  icon: ReactElement; // lucide-react-native 아이콘
+  title: string;
+  description?: string;
+  action?: ReactElement; // Button 등
+}
+```
+
+### 구현 예시
+
+```tsx
+import { View, Text } from "react-native";
+
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+}: EmptyStateProps): ReactElement {
+  return (
+    <View className="flex items-center gap-5 py-16">
+      <View className="h-16 w-16 items-center justify-center rounded-full bg-blue-200/40">
+        {icon}
+      </View>
+      <View className="items-center gap-1.5">
+        <Text className="text-sm font-semibold text-black-600">{title}</Text>
+        {description ? (
+          <Text className="text-xs text-black-300">{description}</Text>
+        ) : null}
+      </View>
+      {action}
+    </View>
+  );
+}
+```
+
+---
+
+## LikeButton
+
+웹 원본: `src/features/epigram-like/ui/LikeButton.tsx`.
+
+### Props
+
+```ts
+interface LikeButtonProps {
+  epigramId: number;
+  likeCount: number;
+  isLiked: boolean;
+  onToggle: () => void;
+  isPending?: boolean;
+}
+```
+
+### 구현 포인트
+
+- `Heart` 아이콘 (lucide-react-native) — `fill={isLiked ? "#ffffff" : "none"}`
+- `isLiked` true → `bg-black-500 text-white`
+- `isLiked` false → `border border-blue-300 text-blue-600`
+- `active:scale-95`로 피드백
+
+---
+
+## 컴포넌트 네이밍·파일 구조 규칙
+
+웹의 FSD 구조와 컨벤션을 그대로 유지:
+
+```
+src/
+├── shared/
+│   └── ui/
+│       ├── Button.tsx
+│       ├── Input.tsx
+│       ├── Textarea.tsx
+│       ├── Tag.tsx
+│       ├── Modal.tsx
+│       ├── BottomSheet.tsx        # 모바일 전용 추가
+│       ├── Toast.tsx              # 모바일 전용 추가
+│       ├── Skeleton.tsx           # 모바일 전용 추가
+│       ├── Avatar.tsx             # 모바일 전용 추가
+│       ├── IconButton.tsx         # 모바일 전용 추가
+│       └── EmptyState.tsx
+├── entities/
+│   └── epigram/
+│       └── ui/
+│           └── EpigramCard.tsx
+└── widgets/
+    └── bottom-tab-bar/            # 모바일 전용 추가
+```
+
+웹 `shared/ui/Modal.tsx`의 `Modal` + `ConfirmModal` 같이 **관련 헬퍼 컴포넌트는 같은 파일에** 두는 관행을 모바일에서도 유지한다 (헌법 III 원칙).

--- a/.claude/skills/epigram-mobile-design-system/patterns.md
+++ b/.claude/skills/epigram-mobile-design-system/patterns.md
@@ -1,0 +1,438 @@
+# Epigram Mobile UX Patterns
+
+웹(`hover`, `cursor`, `<button>`, `<a>`)에서 모바일(`Pressable`, `FlatList`, `BottomSheet`)로 인터랙션을 변환할 때 지켜야 할 패턴 모음.
+
+---
+
+## 1. 터치 영역 (Touch Targets)
+
+### 원칙
+
+모든 인터랙티브 요소는 **최소 44×44pt (iOS HIG) / 48×48dp (Material)** 의 터치 영역을 확보한다.
+
+### 적용 방법
+
+- **버튼**: `min-h-[44px]` 클래스 또는 `padding`으로 확보
+- **아이콘 버튼**: `Pressable`에 `hitSlop` prop으로 시각적 크기 없이 터치 영역만 확장
+
+```tsx
+<Pressable
+  onPress={handlePress}
+  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+  // 시각적으로는 28×28이어도 실제 터치는 44×44
+>
+  <X size={28} color="#454545" />
+</Pressable>
+```
+
+### 간격
+
+인접한 터치 요소 사이 **최소 8pt** 간격 확보 — 실수 터치 방지.
+
+---
+
+## 2. Pressed / Active 상태
+
+### 웹 → 모바일 매핑
+
+| 웹 | 모바일 (NativeWind v4) |
+|---|---|
+| `hover:bg-blue-100` | `active:bg-blue-100` |
+| `hover:opacity-80` | `active:opacity-80` |
+| `active:scale-95` | `active:scale-95` (동일) |
+| `focus:ring-2` | RN은 미지원 — `active:border-2 active:border-black-500` 로 대체 |
+
+### 기본 피드백 패턴
+
+- **주요 버튼**: 배경색 변화 (`active:bg-black-600`)
+- **보조 버튼**: 배경색 연하게 (`active:bg-blue-200`)
+- **아이콘 버튼**: `active:opacity-60` 또는 원형 배경 (`active:bg-blue-200`)
+- **카드 탭**: `active:opacity-80` (과도한 스케일 변화는 피함)
+- **텍스트 링크**: `active:opacity-60`
+
+### iOS 느낌 vs Android 느낌
+
+- iOS 네이티브는 **opacity**가 자연스럽다 → `Pressable` 기본 동작(`android_ripple`은 Android만)
+- Android는 **Ripple Effect** 사용 권장
+  ```tsx
+  <Pressable
+    onPress={handlePress}
+    android_ripple={{ color: "#cbd3e1" /* blue-300 */ }}
+  >
+  ```
+
+---
+
+## 3. 웹 컴포넌트 → 모바일 네이티브 UI 매핑
+
+| 웹 패턴 | 모바일 대체 | 이유 |
+|---|---|---|
+| `<select>` / Dropdown | **BottomSheet** 또는 **ActionSheet** | 작은 화면에서 선택지가 시각적으로 더 명확 |
+| 풀스크린 Modal | **BottomSheet** (짧은 콘텐츠) / **`presentationStyle="pageSheet"`** (긴 콘텐츠) | iOS 제스처 친화적 |
+| 드롭다운 메뉴 (more) | **ActionSheet** | 모바일 네이티브 패턴 |
+| 호버 Tooltip | **LongPress** 시 바텀시트 또는 Toast | 호버가 불가능 |
+| `<a>` 앵커 네비 | `Link` from `expo-router` 또는 `router.push()` | Expo Router 파일 기반 라우팅 |
+| 페이지네이션 "더보기" 버튼 | **Infinite Scroll** (`onEndReached`) | 스크롤 연속성 |
+
+---
+
+## 4. 리스트 (FlatList) 패턴
+
+### 원칙
+
+- **`FlatList`를 기본으로 사용** (`ScrollView` + `map`은 성능 문제)
+- 아이템이 100개 이상이면 `initialNumToRender`, `windowSize` 튜닝
+
+### 표준 리스트 구성
+
+```tsx
+import { FlatList, RefreshControl, View } from "react-native";
+
+function EpigramFeedList(): ReactElement {
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    hasNextPage,
+    refetch,
+    fetchNextPage,
+  } = useEpigrams({ limit: 10 });
+
+  const epigrams = data?.pages.flatMap((p) => p.list) ?? [];
+
+  if (isLoading) return <FeedSkeleton />;
+  if (epigrams.length === 0) return <FeedEmpty />;
+
+  return (
+    <FlatList
+      data={epigrams}
+      keyExtractor={(item) => String(item.id)}
+      renderItem={({ item }) => <EpigramCard epigram={item} />}
+      ItemSeparatorComponent={() => <View className="h-4" />}
+      contentContainerClassName="px-6 py-4"
+      onEndReached={() => hasNextPage && fetchNextPage()}
+      onEndReachedThreshold={0.5}
+      refreshControl={
+        <RefreshControl
+          refreshing={isRefreshing}
+          onRefresh={refetch}
+          tintColor="#52698e" // blue-700
+        />
+      }
+      ListFooterComponent={hasNextPage ? <ListLoadingFooter /> : null}
+    />
+  );
+}
+```
+
+### Pull-to-Refresh
+
+- **모든 피드·리스트 화면**에 적용한다
+- `tintColor`를 `blue-700` (`#52698e`)로 통일
+
+### Infinite Scroll
+
+- `onEndReached` + `onEndReachedThreshold={0.5}` 조합
+- React Query의 `useInfiniteQuery`로 서버 상태 관리 (웹 헌법 VI 참고)
+- 로딩 중 푸터에 `ActivityIndicator` 또는 Skeleton 노출
+
+---
+
+## 5. 키보드 & 입력
+
+### 원칙
+
+- 입력 중 키보드가 인풋을 가리지 않게 **`KeyboardAvoidingView`** 또는 **`react-native-keyboard-controller`** 사용
+- 입력 필드 밖 탭 시 키보드 dismiss
+
+### 표준 패턴
+
+```tsx
+import { KeyboardAvoidingView, Platform, ScrollView, TouchableWithoutFeedback, Keyboard } from "react-native";
+
+<KeyboardAvoidingView
+  behavior={Platform.OS === "ios" ? "padding" : "height"}
+  className="flex-1"
+>
+  <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+    <ScrollView keyboardShouldPersistTaps="handled">
+      {/* 폼 */}
+    </ScrollView>
+  </TouchableWithoutFeedback>
+</KeyboardAvoidingView>
+```
+
+### 인풋 타입별 설정
+
+| 용도 | props |
+|---|---|
+| 이메일 | `keyboardType="email-address"`, `autoCapitalize="none"`, `autoComplete="email"` |
+| 비밀번호 | `secureTextEntry`, `autoCapitalize="none"`, `autoComplete="password"` |
+| 닉네임 | `autoCapitalize="none"`, `autoComplete="username"` |
+| 숫자 | `keyboardType="number-pad"` |
+| 본문 (Textarea) | `multiline`, `textAlignVertical="top"` |
+
+### 제출 흐름
+
+- Input의 `returnKeyType="next"` + `onSubmitEditing={() => nextRef.current?.focus()}`
+- 마지막 Input은 `returnKeyType="done"` + `onSubmitEditing={handleSubmit}`
+
+---
+
+## 6. 네비게이션 (Expo Router)
+
+### 구조
+
+```
+app/
+├── (auth)/                 # 인증 전 플로우 그룹
+│   ├── _layout.tsx         # Stack
+│   ├── login.tsx
+│   └── signup.tsx
+├── (tabs)/                 # 인증 후 메인 플로우
+│   ├── _layout.tsx         # Tabs (BottomTabBar)
+│   ├── feeds.tsx
+│   ├── search.tsx
+│   ├── addepigram.tsx
+│   └── mypage.tsx
+├── epigrams/
+│   ├── [id]/
+│   │   ├── index.tsx       # 상세
+│   │   └── edit.tsx        # 수정 (모달 스타일)
+└── _layout.tsx             # 루트
+```
+
+### 화면 전환 스타일
+
+- **일반 화면**: Stack의 `animation: "slide_from_right"` (iOS 기본)
+- **모달성 화면** (작성·수정): `presentation: "modal"` + 상단 "취소" / "저장" 헤더
+- **바텀시트**: Expo Router 제공 `presentation: "formSheet"` 또는 `@gorhom/bottom-sheet` 라이브러리
+
+### 딥링크
+
+- Expo의 `scheme` 설정 + `expo-router`가 자동 처리
+- 카카오 OAuth 콜백은 `epigram://oauth/callback/kakao`로 받음
+
+---
+
+## 7. Safe Area
+
+### 원칙
+
+- 모든 화면은 **`SafeAreaView`** 또는 **`useSafeAreaInsets`** 로 노치·홈 인디케이터 영역 보호
+- 헤더·탭바가 있는 화면은 Expo Router가 자동 처리 — 추가 작업 불필요
+- 모달·전체화면 콘텐츠는 수동 처리
+
+```tsx
+import { SafeAreaView } from "react-native-safe-area-context";
+
+<SafeAreaView edges={["top", "bottom"]} className="flex-1 bg-background">
+  {/* 콘텐츠 */}
+</SafeAreaView>
+```
+
+---
+
+## 8. 애니메이션
+
+### 웹 애니메이션 토큰 → RN 매핑
+
+웹 `globals.css`에 정의된 키프레임:
+
+| 웹 이름 | 용도 | 모바일 구현 |
+|---|---|---|
+| `fade-in-up` | 카드 등장 | `Animated.parallel([opacity 0→1, translateY 16→0])`, 550ms |
+| `fade-in` | 에러 메시지 | `Animated.timing(opacity, 400ms)` |
+| `slide-up` | 모달·시트 | 라이브러리 기본 `animationType="slide"` 사용 |
+| `scale-in` | 칩·토스트 | `Animated.spring` 또는 `Reanimated` |
+| `float` | 장식 | `Animated.loop` |
+
+### 추천 스택
+
+- **단순 전환**: RN 기본 `Animated` API
+- **복잡한 제스처/인터랙티브**: `react-native-reanimated` + `react-native-gesture-handler`
+
+### 성능 원칙
+
+- `useNativeDriver: true` 필수 (opacity, transform 계열)
+- 리스트 아이템 등장 애니메이션은 과도하면 스크롤 버벅임 → 화면 초기 진입 시에만 적용
+
+---
+
+## 9. Loading / Empty / Error 상태
+
+### 3가지 상태를 항상 명시적으로 처리
+
+```tsx
+function FeedScreen(): ReactElement {
+  const { data, isLoading, error, refetch } = useEpigrams();
+
+  if (isLoading) return <FeedSkeleton />;
+  if (error) return <ErrorView onRetry={refetch} />;
+  if (!data || data.length === 0) return <FeedEmpty />;
+
+  return <FeedList epigrams={data} />;
+}
+```
+
+### Skeleton 우선
+
+- **스피너보다 Skeleton을 우선** (헌법 VI 참고)
+- 실제 레이아웃과 같은 크기·위치로 배치해 레이아웃 시프트 방지
+
+### Error
+
+- 네트워크 에러 → 재시도 버튼이 있는 에러 뷰
+- 에러 UI는 `EmptyState` 컴포넌트를 재사용하며 `icon={<WifiOff />}` 같이 상황에 맞는 아이콘 지정
+
+---
+
+## 10. 접근성 (Accessibility)
+
+### 필수 체크
+
+- `accessibilityRole` — `button`, `link`, `header`, `image` 등
+- `accessibilityLabel` — 시각적 텍스트가 없는 요소(아이콘 버튼, 이미지)
+- `accessibilityHint` — 행동의 결과가 명확하지 않을 때
+- `accessibilityState` — `{ disabled, selected, expanded }`
+
+### Modal / BottomSheet
+
+```tsx
+<Modal
+  accessible
+  accessibilityViewIsModal
+  accessibilityRole="alert"
+  accessibilityLabel="확인 대화상자"
+>
+```
+
+### 폼 에러
+
+- Input의 `accessibilityLiveRegion="polite"` 또는 에러 텍스트에 `accessibilityRole="alert"`
+
+### 충분한 대비
+
+- 토큰상 텍스트는 `black-500` 이상(`#454545` → 대비 ≥ 9:1)을 배경 위에 사용
+- 비활성 텍스트는 `gray-300`(`#ababab`) 이상 사용 (`gray-400`은 보조 정보에만)
+
+---
+
+## 11. 폼 (React Hook Form + Zod)
+
+웹 헌법 IV의 패턴을 그대로 사용. RN에서는 `Input`과 연결할 때 `Controller`를 사용한다.
+
+```tsx
+import { useForm, Controller } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+const { control, handleSubmit, formState: { errors, isSubmitting } } = useForm({
+  resolver: zodResolver(loginSchema),
+  mode: "onBlur",
+});
+
+<Controller
+  control={control}
+  name="email"
+  render={({ field: { onChange, onBlur, value } }) => (
+    <Input
+      placeholder="이메일"
+      value={value}
+      onChangeText={onChange}
+      onBlur={onBlur}
+      error={errors.email?.message}
+      keyboardType="email-address"
+      autoCapitalize="none"
+    />
+  )}
+/>
+```
+
+---
+
+## 12. 제스처 패턴
+
+| 제스처 | 사용처 | 구현 |
+|---|---|---|
+| Swipe to go back | 모든 Stack 화면 | Expo Router 기본 (iOS) |
+| Swipe to delete | 내 에피그램·댓글 목록 | `react-native-gesture-handler`의 `Swipeable` |
+| Pull to refresh | 피드·검색 결과 | `FlatList`의 `refreshControl` |
+| Long press | 공유·삭제 메뉴 | `Pressable`의 `onLongPress` + BottomSheet |
+| Pinch to zoom | 이미지 뷰어 (있는 경우) | `react-native-gesture-handler` + `react-native-reanimated` |
+
+---
+
+## 13. 아이콘 규칙 (헌법 준수)
+
+- **`lucide-react-native`만 사용.** SVG 인라인 / 이미지 파일 / 폰트 아이콘 금지
+- 기본 size: `24`, 작은 곳 `16` 또는 `20`, 큰 장식 `32`~`40`
+- `color`는 토큰 색상 hex 값으로 전달 (`"#454545"` 등)
+- `strokeWidth={2}`가 기본, 얇은 라인이 필요하면 `{1.5}`
+
+```tsx
+import { Heart, Search, User } from "lucide-react-native";
+
+<Heart size={20} color="#52698e" strokeWidth={2} fill="#52698e" />
+```
+
+---
+
+## 14. 상태 저장 (웹 ↔ 모바일 차이)
+
+### 웹
+- OAuth 토큰: HttpOnly 쿠키 + BFF 프록시
+
+### 모바일
+- OAuth 토큰: **`expo-secure-store`** (iOS Keychain / Android EncryptedSharedPreferences)
+- 백엔드 API 직접 호출 + `Authorization: Bearer <accessToken>` 헤더
+
+```ts
+import * as SecureStore from "expo-secure-store";
+
+await SecureStore.setItemAsync("accessToken", token);
+const token = await SecureStore.getItemAsync("accessToken");
+```
+
+- **localStorage / AsyncStorage에 토큰 저장 금지** (헌법 VII 준수)
+- 비민감 데이터(최근 검색어 등)는 `@react-native-async-storage/async-storage` 사용
+
+---
+
+## 15. 화면별 레이아웃 원칙
+
+| 화면 | 헤더 | 탭바 | 주요 패턴 |
+|---|---|---|---|
+| 랜딩 | 없음 (로고만) | 없음 | 풀스크린 + CTA 버튼 |
+| 로그인·회원가입 | 뒤로가기만 | 없음 | `KeyboardAvoidingView` + 폼 |
+| 피드 | 로고 + 검색 아이콘 | 표시 | `FlatList` + Pull-to-refresh |
+| 에피그램 상세 | 뒤로가기 + 더보기 | 숨김 | `ScrollView` + 하단 고정 좋아요 바 |
+| 작성·수정 | 취소 / 저장 | 숨김 | 풀스크린 modal, `KeyboardAvoidingView` |
+| 검색 | 검색바 | 표시 | 최근 검색 Chip + 결과 `FlatList` |
+| 마이 | 프로필 헤더 | 표시 | 탭 전환 (감정 캘린더 / 내 글 / 내 댓글) |
+
+---
+
+## 16. 다크 모드 (준비만)
+
+- 현재 목표는 **라이트 모드 우선**. 토큰에 `background.dark`, `surface.dark`가 준비돼 있음
+- 적용 시점엔 `useColorScheme`과 NativeWind의 `dark:` variant 사용
+- 감정 illustration 색(yellow/green/purple/…)은 다크모드에서도 채도 유지 가능 — 변환 불필요
+
+```tsx
+<View className="bg-background dark:bg-background-dark">
+```
+
+---
+
+## 체크리스트 (화면 구현 시)
+
+- [ ] 모든 터치 요소가 44×44pt 이상인가? (`hitSlop` 또는 `min-h-[44px]`)
+- [ ] 리스트는 `FlatList`를 사용했는가?
+- [ ] Pull-to-refresh가 동작하는가?
+- [ ] 키보드가 입력 필드를 가리지 않는가? (`KeyboardAvoidingView`)
+- [ ] Loading / Empty / Error 3가지 상태가 모두 구현됐는가?
+- [ ] 접근성 props(`accessibilityRole`, `accessibilityLabel`)가 지정됐는가?
+- [ ] Safe Area가 고려됐는가?
+- [ ] 아이콘은 `lucide-react-native`에서 가져왔는가?
+- [ ] 토큰이 올바르게 사용됐는가? (임의 hex 없음)
+- [ ] 웹과 동일한 Props 시그니처·네이밍 컨벤션을 유지했는가?

--- a/.claude/skills/epigram-mobile-design-system/tokens.json
+++ b/.claude/skills/epigram-mobile-design-system/tokens.json
@@ -1,0 +1,117 @@
+{
+  "colors": {
+    "black": {
+      "100": "#787878",
+      "200": "#6b6b6b",
+      "300": "#5e5e5e",
+      "400": "#525252",
+      "500": "#454545",
+      "600": "#373737",
+      "700": "#2b2b2b",
+      "800": "#1f1f1f",
+      "900": "#121212",
+      "950": "#050505"
+    },
+    "blue": {
+      "100": "#ffffff",
+      "200": "#eceff4",
+      "300": "#cbd3e1",
+      "400": "#abb8ce",
+      "500": "#8b9dbc",
+      "600": "#6a82a9",
+      "700": "#52698e",
+      "800": "#40516e",
+      "900": "#2d394e",
+      "950": "#1a212d"
+    },
+    "gray": {
+      "100": "#dedede",
+      "200": "#c4c4c4",
+      "300": "#ababab",
+      "400": "#919191"
+    },
+    "background": {
+      "DEFAULT": "#f5f7fa",
+      "dark": "#1a212d"
+    },
+    "surface": {
+      "DEFAULT": "#ffffff",
+      "dark": "#2d394e"
+    },
+    "line": {
+      "100": "#f2f2f2",
+      "200": "#cfdbea"
+    },
+    "error": "#ff6577",
+    "illust": {
+      "yellow": "#fbc85b",
+      "green": "#48bb98",
+      "purple": "#8e80e3",
+      "blue": "#5195ee",
+      "red": "#e46e80",
+      "brown": "#9a695e"
+    },
+    "sub": {
+      "yellow": "#e8aa26",
+      "blue-1": "#3e3e3e",
+      "blue-2": "#3e414d",
+      "blue-3": "#494d59",
+      "gray-1": "#c7d1e0",
+      "gray-2": "#e3e9f1",
+      "gray-3": "#eff3f8"
+    }
+  },
+  "fontSize": {
+    "xs": { "size": 12, "lineHeight": 16 },
+    "sm": { "size": 14, "lineHeight": 20 },
+    "base": { "size": 16, "lineHeight": 24 },
+    "lg": { "size": 18, "lineHeight": 28 },
+    "xl": { "size": 20, "lineHeight": 28 },
+    "2xl": { "size": 24, "lineHeight": 32 },
+    "3xl": { "size": 30, "lineHeight": 36 },
+    "4xl": { "size": 36, "lineHeight": 40 },
+    "epigram-sm": { "size": 16, "lineHeight": 26 },
+    "epigram-base": { "size": 18, "lineHeight": 30 },
+    "epigram-lg": { "size": 20, "lineHeight": 34 }
+  },
+  "fontWeight": {
+    "normal": "400",
+    "medium": "500",
+    "semibold": "600",
+    "bold": "700",
+    "black": "900"
+  },
+  "fontFamily": {
+    "sans": "Pretendard",
+    "serif": "NanumMyeongjo",
+    "serif-bold": "NanumMyeongjo-Bold"
+  },
+  "spacing": {
+    "touch-sm": 40,
+    "touch-md": 44,
+    "touch-lg": 48,
+    "screen-x": 24,
+    "screen-x-sm": 16,
+    "header-h": 52,
+    "tab-h": 56,
+    "card-p": 24,
+    "card-p-sm": 16
+  },
+  "borderRadius": {
+    "none": 0,
+    "sm": 4,
+    "DEFAULT": 8,
+    "md": 10,
+    "lg": 12,
+    "xl": 16,
+    "2xl": 20,
+    "3xl": 24,
+    "full": 9999
+  },
+  "duration": {
+    "fast": 150,
+    "base": 200,
+    "slow": 350,
+    "slower": 550
+  }
+}

--- a/.claude/skills/epigram-mobile-design-system/tokens.ts
+++ b/.claude/skills/epigram-mobile-design-system/tokens.ts
@@ -1,0 +1,235 @@
+/**
+ * Epigram Mobile Design Tokens
+ *
+ * NativeWind v4 + Tailwind CSS 3.4 호환.
+ * tailwind.config.js의 theme.extend에 spread해서 사용한다.
+ *
+ * @example
+ * // tailwind.config.js
+ * const { colors, fontSize, spacing, borderRadius, fontFamily, fontWeight } = require("./tokens");
+ * module.exports = {
+ *   theme: {
+ *     extend: { colors, fontSize, spacing, borderRadius, fontFamily, fontWeight },
+ *   },
+ * };
+ *
+ * 원본: epigram 웹 프로젝트 src/app/globals.css @theme 블록
+ */
+
+/* ============================================================
+ * Colors
+ * 웹 globals.css의 --color-* 변수를 그대로 매핑한다.
+ * 웹은 라이트 모드 중심 — 모바일도 동일하지만 dark 변형 토큰을 준비했다.
+ * ============================================================ */
+export const colors = {
+  // Neutral gray scale (브랜드의 기본 텍스트/UI 색)
+  black: {
+    100: "#787878",
+    200: "#6b6b6b",
+    300: "#5e5e5e",
+    400: "#525252",
+    500: "#454545", // Primary text & Button primary bg
+    600: "#373737", // Button primary hover
+    700: "#2b2b2b",
+    800: "#1f1f1f",
+    900: "#121212", // Heading 강조
+    950: "#050505", // Input text
+  },
+
+  // Blue (brand primary) — 피그마 시안의 파란 톤
+  blue: {
+    100: "#ffffff", // 실제로는 흰색으로 사용됨 (web 원본 그대로)
+    200: "#eceff4", // Input bg, Tag bg light
+    300: "#cbd3e1", // Disabled, divider
+    400: "#abb8ce", // Placeholder, secondary text
+    500: "#8b9dbc", // Calendar weekday
+    600: "#6a82a9", // Tag text, accent
+    700: "#52698e", // Active nav text
+    800: "#40516e",
+    900: "#2d394e", // Label text
+    950: "#1a212d", // Selection text
+  },
+
+  // Gray (보조 회색, 아이콘·비활성 텍스트)
+  gray: {
+    100: "#dedede",
+    200: "#c4c4c4",
+    300: "#ababab",
+    400: "#919191",
+  },
+
+  // Background — 화면 배경색
+  background: {
+    DEFAULT: "#f5f7fa", // 라이트 모드 기본
+    dark: "#1a212d", // 다크 모드용 (blue-950)
+  },
+
+  // Surface — 카드·시트·모달의 표면 색
+  surface: {
+    DEFAULT: "#ffffff",
+    dark: "#2d394e", // 다크 모드 (blue-900)
+  },
+
+  // Line (border)
+  line: {
+    100: "#f2f2f2", // Subtle divider (카드 테두리)
+    200: "#cfdbea", // Regular divider
+  },
+
+  // State
+  error: "#ff6577",
+
+  // Illustration (감정 로그·차트 용)
+  illust: {
+    yellow: "#fbc85b",
+    green: "#48bb98",
+    purple: "#8e80e3",
+    blue: "#5195ee",
+    red: "#e46e80",
+    brown: "#9a695e",
+  },
+
+  // Sub (보조 색상 — 다크 배경·섹션 구분 등)
+  sub: {
+    yellow: "#e8aa26",
+    "blue-1": "#3e3e3e",
+    "blue-2": "#3e414d",
+    "blue-3": "#494d59",
+    "gray-1": "#c7d1e0",
+    "gray-2": "#e3e9f1",
+    "gray-3": "#eff3f8",
+  },
+} as const;
+
+/* ============================================================
+ * Typography
+ * 웹은 `text-xs` ~ `text-xl` 등 Tailwind 기본 스케일을 쓴다.
+ * 모바일에서도 동일 스케일 + PX 단위를 명시해 NativeWind가 정확히 해석하도록 한다.
+ * ============================================================ */
+export const fontSize = {
+  // [fontSize, { lineHeight }]
+  xs: ["12px", { lineHeight: "16px" }],
+  sm: ["14px", { lineHeight: "20px" }],
+  base: ["16px", { lineHeight: "24px" }],
+  lg: ["18px", { lineHeight: "28px" }],
+  xl: ["20px", { lineHeight: "28px" }],
+  "2xl": ["24px", { lineHeight: "32px" }],
+  "3xl": ["30px", { lineHeight: "36px" }],
+  "4xl": ["36px", { lineHeight: "40px" }],
+
+  // Serif 본문용 커스텀 스케일 (에피그램 카드)
+  "epigram-sm": ["16px", { lineHeight: "26px" }],
+  "epigram-base": ["18px", { lineHeight: "30px" }],
+  "epigram-lg": ["20px", { lineHeight: "34px" }],
+} as const;
+
+export const fontWeight = {
+  normal: "400",
+  medium: "500",
+  semibold: "600",
+  bold: "700",
+  black: "900",
+} as const;
+
+/**
+ * Font Family
+ *
+ * RN에서는 expo-font로 폰트를 로드해야 NativeWind의 font-sans / font-serif가 작동한다.
+ * expo-font 로드 예시:
+ *   useFonts({
+ *     "Pretendard": require("./assets/fonts/PretendardVariable.ttf"),
+ *     "NanumMyeongjo": require("./assets/fonts/NanumMyeongjo-Regular.ttf"),
+ *     "NanumMyeongjo-Bold": require("./assets/fonts/NanumMyeongjo-Bold.ttf"),
+ *   });
+ */
+export const fontFamily = {
+  sans: ["Pretendard", "System"],
+  serif: ["NanumMyeongjo", "serif"],
+  "serif-bold": ["NanumMyeongjo-Bold", "serif"],
+} as const;
+
+/* ============================================================
+ * Spacing
+ * Tailwind 기본 4px 스케일을 따른다. 웹 프로젝트도 기본값 사용.
+ * 추가로 모바일 safe-area·터치-타겟용 토큰을 추가한다.
+ * ============================================================ */
+export const spacing = {
+  // 기본 스케일 유지 (0 ~ 96 등은 tailwind 기본값이라 생략)
+
+  // 모바일 전용
+  "touch-sm": "40px", // 권장 최소 터치 타겟 (아이콘 전용)
+  "touch-md": "44px", // iOS HIG 최소 권장 (Apple)
+  "touch-lg": "48px", // Material Design 최소 (Android)
+
+  // 레이아웃 상수
+  "screen-x": "24px", // 기본 좌우 패딩 (px-6)
+  "screen-x-sm": "16px", // 좁은 화면용 (px-4)
+
+  // 헤더·탭바 높이
+  "header-h": "52px", // 웹 모바일 헤더 높이
+  "tab-h": "56px", // BottomTabBar 높이 (safe-area 제외)
+
+  // 카드 내부 패딩
+  "card-p": "24px", // p-6 (웹 EpigramListCard)
+  "card-p-sm": "16px", // p-4 (조밀한 카드)
+} as const;
+
+/* ============================================================
+ * Border Radius
+ * 웹에서는 rounded-xl(12px), rounded-2xl(16px), rounded-full을 주로 사용.
+ * ============================================================ */
+export const borderRadius = {
+  none: "0",
+  sm: "4px",
+  DEFAULT: "8px", // rounded
+  md: "10px",
+  lg: "12px", // rounded-lg (Button, Input — 웹 rounded-xl)
+  xl: "16px", // rounded-xl (Card — 웹 rounded-2xl)
+  "2xl": "20px",
+  "3xl": "24px",
+  full: "9999px", // Chip, Tag, Avatar
+} as const;
+
+/* ============================================================
+ * Shadow
+ * RN은 iOS: shadow* props / Android: elevation 으로 동작한다.
+ * NativeWind v4는 shadow-* 유틸리티를 iOS/Android에 적절히 매핑해준다.
+ *
+ * 아래 값은 참고용 — 실제 사용은 className="shadow-sm" 등 Tailwind 기본 클래스로 한다.
+ * ============================================================ */
+export const boxShadow = {
+  // 웹 카드: shadow-[0px_3px_12px_0_rgba(0,0,0,0.04)]
+  card: "0px 3px 12px rgba(0, 0, 0, 0.04)",
+  sm: "0px 1px 2px rgba(0, 0, 0, 0.05)",
+  md: "0px 4px 6px rgba(0, 0, 0, 0.07)",
+  lg: "0px 10px 15px rgba(0, 0, 0, 0.10)",
+  xl: "0px 20px 25px rgba(0, 0, 0, 0.12)",
+} as const;
+
+/* ============================================================
+ * Animation Duration (RN Animated·Reanimated용 상수)
+ * NativeWind v4는 transition-duration-* 도 지원하지만, RN Animated에는 ms 상수가 더 쓰기 편하다.
+ * ============================================================ */
+export const duration = {
+  fast: 150, // 웹 transition-all duration-150 (버튼)
+  base: 200, // 웹 duration-200 (카드, input)
+  slow: 350, // 웹 slideUp (0.35s)
+  slower: 550, // 웹 fadeInUp (0.55s)
+} as const;
+
+/**
+ * 편의용: 전체 토큰 한 번에 export
+ * tailwind.config.js에서 `...tokens.colors`처럼 쓰려면 default export도 유용하다.
+ */
+export const tokens = {
+  colors,
+  fontSize,
+  fontWeight,
+  fontFamily,
+  spacing,
+  borderRadius,
+  boxShadow,
+  duration,
+} as const;
+
+export default tokens;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@react-navigation/native": "^7.1.8",
         "@tanstack/react-query": "^5.99.2",
         "axios": "^1.15.1",
+        "clsx": "^2.1.1",
         "expo": "~54.0.33",
         "expo-constants": "~18.0.13",
         "expo-font": "~14.0.11",
@@ -5653,6 +5654,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@react-navigation/native": "^7.1.8",
     "@tanstack/react-query": "^5.99.2",
     "axios": "^1.15.1",
+    "clsx": "^2.1.1",
     "expo": "~54.0.33",
     "expo-constants": "~18.0.13",
     "expo-font": "~14.0.11",

--- a/src/shared/config/tokens.js
+++ b/src/shared/config/tokens.js
@@ -1,0 +1,148 @@
+/**
+ * Epigram Mobile Design Tokens
+ *
+ * 원본: .claude/skills/epigram-mobile-design-system/tokens.ts
+ * 이 파일은 tailwind.config.js가 require할 수 있도록 CommonJS로 관리한다.
+ * 토큰 변경 시 스킬 문서와 동기화 필요.
+ */
+
+const colors = {
+  black: {
+    100: "#787878",
+    200: "#6b6b6b",
+    300: "#5e5e5e",
+    400: "#525252",
+    500: "#454545",
+    600: "#373737",
+    700: "#2b2b2b",
+    800: "#1f1f1f",
+    900: "#121212",
+    950: "#050505",
+  },
+  blue: {
+    100: "#ffffff",
+    200: "#eceff4",
+    300: "#cbd3e1",
+    400: "#abb8ce",
+    500: "#8b9dbc",
+    600: "#6a82a9",
+    700: "#52698e",
+    800: "#40516e",
+    900: "#2d394e",
+    950: "#1a212d",
+  },
+  gray: {
+    100: "#dedede",
+    200: "#c4c4c4",
+    300: "#ababab",
+    400: "#919191",
+  },
+  background: {
+    DEFAULT: "#f5f7fa",
+    dark: "#1a212d",
+  },
+  surface: {
+    DEFAULT: "#ffffff",
+    dark: "#2d394e",
+  },
+  line: {
+    100: "#f2f2f2",
+    200: "#cfdbea",
+  },
+  error: "#ff6577",
+  illust: {
+    yellow: "#fbc85b",
+    green: "#48bb98",
+    purple: "#8e80e3",
+    blue: "#5195ee",
+    red: "#e46e80",
+    brown: "#9a695e",
+  },
+  sub: {
+    yellow: "#e8aa26",
+    "blue-1": "#3e3e3e",
+    "blue-2": "#3e414d",
+    "blue-3": "#494d59",
+    "gray-1": "#c7d1e0",
+    "gray-2": "#e3e9f1",
+    "gray-3": "#eff3f8",
+  },
+};
+
+const fontSize = {
+  xs: ["12px", { lineHeight: "16px" }],
+  sm: ["14px", { lineHeight: "20px" }],
+  base: ["16px", { lineHeight: "24px" }],
+  lg: ["18px", { lineHeight: "28px" }],
+  xl: ["20px", { lineHeight: "28px" }],
+  "2xl": ["24px", { lineHeight: "32px" }],
+  "3xl": ["30px", { lineHeight: "36px" }],
+  "4xl": ["36px", { lineHeight: "40px" }],
+  "epigram-sm": ["16px", { lineHeight: "26px" }],
+  "epigram-base": ["18px", { lineHeight: "30px" }],
+  "epigram-lg": ["20px", { lineHeight: "34px" }],
+};
+
+const fontWeight = {
+  normal: "400",
+  medium: "500",
+  semibold: "600",
+  bold: "700",
+  black: "900",
+};
+
+const fontFamily = {
+  sans: ["Pretendard", "System"],
+  serif: ["NanumMyeongjo", "serif"],
+  "serif-bold": ["NanumMyeongjo-Bold", "serif"],
+};
+
+const spacing = {
+  "touch-sm": "40px",
+  "touch-md": "44px",
+  "touch-lg": "48px",
+  "screen-x": "24px",
+  "screen-x-sm": "16px",
+  "header-h": "52px",
+  "tab-h": "56px",
+  "card-p": "24px",
+  "card-p-sm": "16px",
+};
+
+const borderRadius = {
+  none: "0",
+  sm: "4px",
+  DEFAULT: "8px",
+  md: "10px",
+  lg: "12px",
+  xl: "16px",
+  "2xl": "20px",
+  "3xl": "24px",
+  full: "9999px",
+};
+
+const boxShadow = {
+  card: "0px 3px 12px rgba(0, 0, 0, 0.04)",
+  sm: "0px 1px 2px rgba(0, 0, 0, 0.05)",
+  md: "0px 4px 6px rgba(0, 0, 0, 0.07)",
+  lg: "0px 10px 15px rgba(0, 0, 0, 0.10)",
+  xl: "0px 20px 25px rgba(0, 0, 0, 0.12)",
+};
+
+const duration = {
+  fast: 150,
+  base: 200,
+  slow: 350,
+  slower: 550,
+};
+
+module.exports = {
+  colors,
+  fontSize,
+  fontWeight,
+  fontFamily,
+  spacing,
+  borderRadius,
+  boxShadow,
+  duration,
+};

--- a/src/shared/lib/cn.ts
+++ b/src/shared/lib/cn.ts
@@ -1,0 +1,5 @@
+import { clsx, type ClassValue } from "clsx";
+
+export function cn(...inputs: ClassValue[]): string {
+  return clsx(inputs);
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+const tokens = require("./src/shared/config/tokens");
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
@@ -7,7 +9,15 @@ module.exports = {
   ],
   presets: [require("nativewind/preset")],
   theme: {
-    extend: {},
+    extend: {
+      colors: tokens.colors,
+      fontSize: tokens.fontSize,
+      fontWeight: tokens.fontWeight,
+      fontFamily: tokens.fontFamily,
+      spacing: tokens.spacing,
+      borderRadius: tokens.borderRadius,
+      boxShadow: tokens.boxShadow,
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## ✏️ 작업 내용

- `epigram-mobile-design-system` 스킬 커밋
  - `.claude/skills/epigram-mobile-design-system/` (SKILL.md, tokens.ts, tokens.json, components.md, patterns.md)
- 디자인 토큰 CommonJS 미러 추가
  - `src/shared/config/tokens.js` — 스킬의 `tokens.ts`를 tailwind.config.js가 require할 수 있도록 CommonJS로 변환
  - 포함 토큰: `colors`, `fontSize`, `fontWeight`, `fontFamily`, `spacing`, `borderRadius`, `boxShadow`, `duration`
- `tailwind.config.js` 업데이트
  - `theme.extend`에 토큰 spread (duration 제외 — RN Animated용 상수는 JS에서 직접 참조)
- `clsx` 의존성 추가
- `src/shared/lib/cn.ts` 추가
  - `clsx` 기반 className 결합 유틸

## 🗨️ 논의 사항 (참고 사항)

- **단일 진실 공급원**: 스킬 `tokens.ts`가 디자인 토큰의 원본이고, `tokens.js`는 Tailwind 빌드용 미러다. 토큰 변경 시 두 파일을 함께 수정해야 한다.
- **NativeWind v4**는 Tailwind 3.4 preset을 쓰므로 `fontSize` 튜플(`[size, { lineHeight }]`) 포맷을 그대로 사용했다.
- **duration 토큰**은 NativeWind `transition-duration-*`보다 RN `Animated`/`Reanimated`의 ms 상수로 쓰는 게 편해서 theme에 넣지 않았다.
- 폰트(`Pretendard`, `NanumMyeongjo`) 파일 로딩은 후속 작업.

## 기대효과

- NativeWind 유틸리티로 디자인 토큰 즉시 사용 가능
  - `bg-blue-500`, `text-epigram-base`, `rounded-xl`, `p-card-p`, `h-header-h` 등
- `cn("bg-blue-500", isActive && "bg-blue-600")`로 조건부 스타일 일관 처리
- 컴포넌트 구현 시 스킬 `components.md` 스펙 + 토큰 클래스를 그대로 적용 가능

Closes #3
