### PR TITLE
feat: Pretendard·NanumMyeongjo 폰트 로딩 (#5)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,12 +1,21 @@
 import '../global.css';
 
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
+import {
+  NanumMyeongjo_400Regular,
+  NanumMyeongjo_700Bold,
+} from '@expo-google-fonts/nanum-myeongjo';
+import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
+import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
+import { useEffect } from 'react';
 import 'react-native-reanimated';
 
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { QueryProvider } from '~/shared/api/QueryProvider';
+
+SplashScreen.preventAutoHideAsync();
 
 export const unstable_settings = {
   anchor: '(tabs)',
@@ -14,6 +23,21 @@ export const unstable_settings = {
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
+  const [fontsLoaded, fontsError] = useFonts({
+    Pretendard: require('pretendard/dist/public/variable/PretendardVariable.ttf'),
+    NanumMyeongjo: NanumMyeongjo_400Regular,
+    'NanumMyeongjo-Bold': NanumMyeongjo_700Bold,
+  });
+
+  useEffect(() => {
+    if (fontsLoaded || fontsError) {
+      SplashScreen.hideAsync();
+    }
+  }, [fontsLoaded, fontsError]);
+
+  if (!fontsLoaded && !fontsError) {
+    return null;
+  }
 
   return (
     <QueryProvider>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "epigram-mobile",
       "version": "1.0.0",
       "dependencies": {
+        "@expo-google-fonts/nanum-myeongjo": "^0.4.1",
         "@expo/vector-icons": "^15.0.3",
         "@hookform/resolvers": "^5.2.2",
         "@react-navigation/bottom-tabs": "^7.4.0",
@@ -31,6 +32,7 @@
         "expo-web-browser": "~15.0.10",
         "lucide-react-native": "^1.8.0",
         "nativewind": "^4.2.3",
+        "pretendard": "^1.3.9",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-hook-form": "^7.72.1",
@@ -1864,6 +1866,12 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@expo-google-fonts/nanum-myeongjo": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/nanum-myeongjo/-/nanum-myeongjo-0.4.1.tgz",
+      "integrity": "sha512-TS8PRPoimFYTmJQqsFsU3E361T4L3p/+aJa5/d1GpBOi8XAvPJDlYrtySg+sipjXYcFU84B7gIYWO4ir3NhgAw==",
+      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo/cli": {
       "version": "54.0.23",
@@ -10990,6 +10998,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretendard": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/pretendard/-/pretendard-1.3.9.tgz",
+      "integrity": "sha512-PaQAADyLY5v4kYFwkpSJHbSSYIkiriY/1xXw75TKoZ9UQQqeU+tvP05yTdZAWibiIYoo8ZKtRv8PM7w0IaywSw==",
+      "license": "OFL-1.1"
     },
     "node_modules/prettier-plugin-tailwindcss": {
       "version": "0.5.14",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "expo lint"
   },
   "dependencies": {
+    "@expo-google-fonts/nanum-myeongjo": "^0.4.1",
     "@expo/vector-icons": "^15.0.3",
     "@hookform/resolvers": "^5.2.2",
     "@react-navigation/bottom-tabs": "^7.4.0",
@@ -34,6 +35,7 @@
     "expo-web-browser": "~15.0.10",
     "lucide-react-native": "^1.8.0",
     "nativewind": "^4.2.3",
+    "pretendard": "^1.3.9",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-hook-form": "^7.72.1",


### PR DESCRIPTION
## ✏️ 작업 내용

- 폰트 패키지 설치
  - `pretendard` — `PretendardVariable.ttf` (Variable 폰트 1개로 100~900 weight 커버)
  - `@expo-google-fonts/nanum-myeongjo` — Regular(400) + Bold(700)
  - `expo-font`, `expo-splash-screen` (Expo 기본 포함)
- `app/_layout.tsx` 업데이트
  - `useFonts` 훅으로 3개 폰트 로드 — 키 이름을 `Pretendard` / `NanumMyeongjo` / `NanumMyeongjo-Bold`로 등록해 `tailwind.config.js`의 `fontFamily` 토큰과 일치시킴
  - `SplashScreen.preventAutoHideAsync()` + 폰트 로드 완료 시 `hideAsync()` — FOIT(깜빡임) 방지
  - 로드 전에는 `null` 리턴해 앱 렌더 지연

## 🗨️ 논의 사항 (참고 사항)

- Pretendard Variable 폰트는 `font-weight: 100~900` 전 구간을 TTF 한 파일로 처리한다. RN에서도 정상 동작 확인됐음.
- NanumMyeongjo는 Google Fonts 패키지에서 `400Regular` / `700Bold`만 가져왔다. `800ExtraBold`는 현재 디자인 토큰에 없어 제외.
- 폰트 로드 실패(`fontsError`)도 스플래시를 해제해 무한 대기를 방지한다. 시스템 폰트로 fallback된다.

## 기대효과

- `font-sans` → Pretendard, `font-serif` → NanumMyeongjo, `font-serif-bold` → NanumMyeongjo-Bold로 렌더됨
- 디자인 시스템 토큰의 타이포그래피가 실제 UI에 반영 가능한 상태

Closes #5
