### PR TITLE
feat: entities/user 스키마·타입·API·useMe 훅 이식 (#9)

### DIFF
--- a/src/entities/user/api/auth.ts
+++ b/src/entities/user/api/auth.ts
@@ -1,0 +1,36 @@
+import { apiClient } from "~/shared/api/client";
+import { clearTokens, setAccessToken, setRefreshToken } from "~/shared/api/tokenStorage";
+
+import type { SignInResponse, SignUpResponse } from "../model/types";
+
+export interface SignUpBody {
+  email: string;
+  nickname: string;
+  password: string;
+  passwordConfirmation: string;
+}
+
+export interface SignInBody {
+  email: string;
+  password: string;
+}
+
+async function persistTokens(tokens: { accessToken: string; refreshToken: string }): Promise<void> {
+  await Promise.all([setAccessToken(tokens.accessToken), setRefreshToken(tokens.refreshToken)]);
+}
+
+export async function signUp(body: SignUpBody): Promise<SignUpResponse> {
+  const response = await apiClient.post<SignUpResponse>("/auth/signUp", body);
+  await persistTokens(response.data);
+  return response.data;
+}
+
+export async function signIn(body: SignInBody): Promise<SignInResponse> {
+  const response = await apiClient.post<SignInResponse>("/auth/signIn", body);
+  await persistTokens(response.data);
+  return response.data;
+}
+
+export async function logout(): Promise<void> {
+  await clearTokens();
+}

--- a/src/entities/user/api/kakao.ts
+++ b/src/entities/user/api/kakao.ts
@@ -1,0 +1,18 @@
+import { apiClient } from "~/shared/api/client";
+import { setAccessToken, setRefreshToken } from "~/shared/api/tokenStorage";
+
+import type { SignInResponse } from "../model/types";
+
+export interface SignInKakaoBody {
+  token: string;
+  redirectUri: string;
+}
+
+export async function signInKakao(body: SignInKakaoBody): Promise<SignInResponse> {
+  const response = await apiClient.post<SignInResponse>("/auth/signIn/kakao", body);
+  await Promise.all([
+    setAccessToken(response.data.accessToken),
+    setRefreshToken(response.data.refreshToken),
+  ]);
+  return response.data;
+}

--- a/src/entities/user/api/useMe.ts
+++ b/src/entities/user/api/useMe.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { type User } from "../model/schema";
+import { getMe } from "./user";
+
+export function useMe(): { user: User | null; isLoading: boolean } {
+  const { data, isLoading } = useQuery<User | null, Error>({
+    queryKey: ["me"],
+    queryFn: getMe,
+    retry: false,
+    staleTime: Infinity,
+  });
+
+  return { user: data ?? null, isLoading };
+}

--- a/src/entities/user/api/user.ts
+++ b/src/entities/user/api/user.ts
@@ -1,0 +1,19 @@
+import { apiClient } from "~/shared/api/client";
+
+import { userSchema, type User } from "../model/schema";
+
+export interface UpdateMeBody {
+  nickname?: string;
+  image?: string;
+}
+
+export async function getMe(): Promise<User | null> {
+  const response = await apiClient.get<User | null>("/users/me");
+  if (response.data === null) return null;
+  return userSchema.parse(response.data);
+}
+
+export async function updateMe(body: UpdateMeBody): Promise<User> {
+  const response = await apiClient.patch("/users/me", body);
+  return userSchema.parse(response.data);
+}

--- a/src/entities/user/index.ts
+++ b/src/entities/user/index.ts
@@ -1,0 +1,16 @@
+export { userSchema } from "./model/schema";
+export type { User } from "./model/schema";
+export type {
+  AuthTokens,
+  SignInResponse,
+  SignUpResponse,
+  UserWithEmail,
+} from "./model/types";
+
+export { logout, signIn, signUp } from "./api/auth";
+export type { SignInBody, SignUpBody } from "./api/auth";
+export { signInKakao } from "./api/kakao";
+export type { SignInKakaoBody } from "./api/kakao";
+export { getMe, updateMe } from "./api/user";
+export type { UpdateMeBody } from "./api/user";
+export { useMe } from "./api/useMe";

--- a/src/entities/user/model/schema.ts
+++ b/src/entities/user/model/schema.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const userSchema = z.object({
+  id: z.number().int().positive(),
+  nickname: z.string().min(1).max(30),
+  email: z.string().email().optional(),
+  image: z.string().url().nullable(),
+  teamId: z.string(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export type User = z.infer<typeof userSchema>;

--- a/src/entities/user/model/types.ts
+++ b/src/entities/user/model/types.ts
@@ -1,0 +1,22 @@
+export interface UserWithEmail {
+  id: number;
+  nickname: string;
+  email: string;
+  image: string | null;
+  teamId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface SignUpResponse extends AuthTokens {
+  user: UserWithEmail;
+}
+
+export interface SignInResponse extends AuthTokens {
+  user: UserWithEmail;
+}


### PR DESCRIPTION
## ✏️ 작업 내용

- `src/entities/user/` 신규 슬라이스
  - `model/schema.ts` — Zod `userSchema` (웹과 동일)
  - `model/types.ts` — `UserWithEmail`, `AuthTokens`, 토큰 포함 `SignInResponse`/`SignUpResponse`
- API 계층
  - `api/auth.ts` — `signUp`, `signIn`, `logout`
    - 엔드포인트: `/auth/signUp`, `/auth/signIn` (apiClient baseURL이 이미 `${BACKEND}/${TEAM_ID}`)
    - 성공 시 `accessToken`·`refreshToken`을 `setAccessToken`/`setRefreshToken`로 SecureStore에 저장
    - `logout`은 `clearTokens()`로 로컬 토큰만 제거
  - `api/kakao.ts` — `signInKakao` (토큰 저장 동일)
  - `api/user.ts` — `getMe`, `updateMe` (응답을 `userSchema.parse`로 런타임 검증)
  - `api/useMe.ts` — React Query 훅, `staleTime: Infinity` (세션 중 사용자 정보 불변)
- `index.ts` — 퍼블릭 API 재노출

## 🗨️ 논의 사항 (참고 사항)

- **웹 vs 모바일 차이**: 웹은 BFF 프록시(`/api/auth/...`)가 응답의 토큰을 HttpOnly 쿠키로 스트립하지만, 모바일은 백엔드를 직접 호출하고 응답 body의 토큰을 SecureStore에 저장한다. 따라서 `SignInResponse`/`SignUpResponse`는 웹과 달리 `accessToken`·`refreshToken` 필드를 포함한다.
- **logout**: 백엔드에 별도 로그아웃 엔드포인트가 없어 로컬 SecureStore 토큰만 제거한다. (웹의 `/api/auth/logout`은 BFF가 쿠키만 비우는 처리)
- **Zod v4**: 현재 `zod@4`가 설치돼 있으며 `z.string().email()`, `.datetime()` 등 웹과 동일 API 사용. v3→v4 호환 경고가 추후 나올 경우 별도 PR에서 마이그레이션 검토.

## 기대효과

- 타입 안전한 유저 API 계층 확보 (Login·SignUp·Kakao·Me 조회)
- 이후 Login 스크린은 `signIn()` 호출만으로 토큰 저장까지 자동 처리 가능

Closes #9
