### PR TITLE
feat: entities/epigram 스키마·API 훅 이식 (#11)

### DIFF
--- a/src/entities/epigram/api/createEpigram.ts
+++ b/src/entities/epigram/api/createEpigram.ts
@@ -1,0 +1,16 @@
+import { apiClient } from "~/shared/api/client";
+
+import { epigramSchema, type Epigram } from "../model/schema";
+
+export interface CreateEpigramRequest {
+  content: string;
+  author: string;
+  referenceTitle?: string;
+  referenceUrl?: string;
+  tags: string[];
+}
+
+export async function createEpigram(data: CreateEpigramRequest): Promise<Epigram> {
+  const response = await apiClient.post<unknown>("/epigrams", data);
+  return epigramSchema.parse(response.data);
+}

--- a/src/entities/epigram/api/useEpigramDetail.ts
+++ b/src/entities/epigram/api/useEpigramDetail.ts
@@ -1,0 +1,16 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { apiClient } from "~/shared/api/client";
+
+import { epigramDetailSchema, type EpigramDetail } from "../model/schema";
+
+export function useEpigramDetail(id: number): UseQueryResult<EpigramDetail, Error> {
+  return useQuery({
+    queryKey: ["epigrams", id],
+    enabled: id > 0,
+    queryFn: async () => {
+      const response = await apiClient.get<unknown>(`/epigrams/${id}`);
+      return epigramDetailSchema.parse(response.data);
+    },
+  });
+}

--- a/src/entities/epigram/api/useEpigrams.ts
+++ b/src/entities/epigram/api/useEpigrams.ts
@@ -1,0 +1,39 @@
+import {
+  useInfiniteQuery,
+  type InfiniteData,
+  type UseInfiniteQueryResult,
+} from "@tanstack/react-query";
+
+import { apiClient } from "~/shared/api/client";
+
+import { epigramListResponseSchema, type EpigramListResponse } from "../model/schema";
+
+interface UseEpigramsParams {
+  limit: number;
+  keyword?: string;
+  writerId?: number;
+}
+
+export function useEpigrams({
+  limit,
+  keyword,
+  writerId,
+}: UseEpigramsParams): UseInfiniteQueryResult<
+  InfiniteData<EpigramListResponse, number | undefined>,
+  Error
+> {
+  return useInfiniteQuery({
+    queryKey: ["epigrams", { limit, keyword, writerId }],
+    queryFn: async ({ pageParam }) => {
+      const params = new URLSearchParams({ limit: String(limit) });
+      if (pageParam !== undefined) params.set("cursor", String(pageParam));
+      if (keyword) params.set("keyword", keyword);
+      if (writerId !== undefined) params.set("writerId", String(writerId));
+
+      const response = await apiClient.get<unknown>(`/epigrams?${params}`);
+      return epigramListResponseSchema.parse(response.data);
+    },
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+  });
+}

--- a/src/entities/epigram/api/useSearchEpigrams.ts
+++ b/src/entities/epigram/api/useSearchEpigrams.ts
@@ -1,0 +1,36 @@
+import {
+  useInfiniteQuery,
+  type InfiniteData,
+  type UseInfiniteQueryResult,
+} from "@tanstack/react-query";
+
+import { apiClient } from "~/shared/api/client";
+
+import { epigramListResponseSchema, type EpigramListResponse } from "../model/schema";
+
+interface UseSearchEpigramsParams {
+  keyword: string;
+  limit: number;
+}
+
+export function useSearchEpigrams({
+  keyword,
+  limit,
+}: UseSearchEpigramsParams): UseInfiniteQueryResult<
+  InfiniteData<EpigramListResponse, number | undefined>,
+  Error
+> {
+  return useInfiniteQuery({
+    queryKey: ["search", "epigrams", keyword],
+    queryFn: async ({ pageParam }) => {
+      const params = new URLSearchParams({ limit: String(limit), keyword });
+      if (pageParam !== undefined) params.set("cursor", String(pageParam));
+
+      const response = await apiClient.get<unknown>(`/epigrams?${params}`);
+      return epigramListResponseSchema.parse(response.data);
+    },
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    enabled: keyword.trim().length > 0,
+  });
+}

--- a/src/entities/epigram/api/useTodayEpigram.ts
+++ b/src/entities/epigram/api/useTodayEpigram.ts
@@ -1,0 +1,18 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { apiClient } from "~/shared/api/client";
+
+import { epigramSchema, type Epigram } from "../model/schema";
+
+// /today 엔드포인트는 인증 없는 공개 API라 isLiked를 반환하지 않음.
+// swagger의 EpigramDetailType 명세와 실제 응답이 불일치하므로 epigramSchema를 사용한다.
+export function useTodayEpigram(): UseQueryResult<Epigram | null, Error> {
+  return useQuery({
+    queryKey: ["epigrams", "today"],
+    queryFn: async () => {
+      const response = await apiClient.get<unknown>("/epigrams/today");
+      if (response.data == null || typeof response.data !== "object") return null;
+      return epigramSchema.parse(response.data);
+    },
+  });
+}

--- a/src/entities/epigram/index.ts
+++ b/src/entities/epigram/index.ts
@@ -1,0 +1,14 @@
+export {
+  epigramDetailSchema,
+  epigramListResponseSchema,
+  epigramSchema,
+  epigramTagSchema,
+} from "./model/schema";
+export type { Epigram, EpigramDetail, EpigramListResponse, EpigramTag } from "./model/schema";
+
+export { createEpigram } from "./api/createEpigram";
+export type { CreateEpigramRequest } from "./api/createEpigram";
+export { useEpigramDetail } from "./api/useEpigramDetail";
+export { useEpigrams } from "./api/useEpigrams";
+export { useSearchEpigrams } from "./api/useSearchEpigrams";
+export { useTodayEpigram } from "./api/useTodayEpigram";

--- a/src/entities/epigram/model/schema.ts
+++ b/src/entities/epigram/model/schema.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+import { buildPaginatedSchema } from "~/shared/types/pagination";
+
+export const epigramTagSchema = z.object({
+  id: z.number().int().positive(),
+  name: z.string().min(1).max(10),
+});
+
+export const epigramSchema = z.object({
+  id: z.number().int().positive(),
+  content: z.string().min(1).max(500),
+  author: z.string().min(1).max(30),
+  referenceTitle: z.string().max(100).nullable(),
+  referenceUrl: z
+    .string()
+    .regex(/^https?:\/\/.+/)
+    .nullable(),
+  writerId: z.number().int().positive(),
+  tags: z.array(epigramTagSchema),
+  likeCount: z.number(),
+});
+
+export const epigramDetailSchema = epigramSchema.extend({
+  isLiked: z.boolean(),
+});
+
+export const epigramListResponseSchema = buildPaginatedSchema(epigramSchema);
+
+export type EpigramTag = z.infer<typeof epigramTagSchema>;
+export type Epigram = z.infer<typeof epigramSchema>;
+export type EpigramDetail = z.infer<typeof epigramDetailSchema>;
+export type EpigramListResponse = z.infer<typeof epigramListResponseSchema>;

--- a/src/shared/types/pagination.ts
+++ b/src/shared/types/pagination.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export interface PaginatedResponse<T> {
+  totalCount: number;
+  nextCursor: number | null;
+  list: T[];
+}
+
+export function buildPaginatedSchema<T extends z.ZodTypeAny>(
+  itemSchema: T
+): z.ZodObject<{
+  totalCount: z.ZodNumber;
+  nextCursor: z.ZodNullable<z.ZodNumber>;
+  list: z.ZodArray<T>;
+}> {
+  return z.object({
+    totalCount: z.number(),
+    nextCursor: z.number().nullable(),
+    list: z.array(itemSchema),
+  });
+}
+
+export type PaginatedSchemaOf<T extends z.ZodTypeAny> = ReturnType<typeof buildPaginatedSchema<T>>;


### PR DESCRIPTION
## ✏️ 작업 내용

- 공통 유틸
  - `src/shared/types/pagination.ts` — `PaginatedResponse<T>`, `buildPaginatedSchema`, `PaginatedSchemaOf`
- 모델
  - `src/entities/epigram/model/schema.ts` — `epigramTagSchema`, `epigramSchema`, `epigramDetailSchema`, `epigramListResponseSchema` + 타입 추론
- API 훅 (`apiClient` 직접 호출, 엔드포인트 `/api/` prefix 제거)
  - `createEpigram.ts` — `POST /epigrams`
  - `useEpigrams.ts` — `GET /epigrams` 무한 스크롤 (`cursor` 기반), `keyword`·`writerId` 필터
  - `useSearchEpigrams.ts` — 검색 전용 무한 스크롤, `keyword.trim().length > 0`일 때만 `enabled`
  - `useTodayEpigram.ts` — `GET /epigrams/today` (공개 API라 `epigramSchema` 사용, `isLiked` 없음)
  - `useEpigramDetail.ts` — `GET /epigrams/:id` (`epigramDetailSchema`로 `isLiked` 포함 검증)
- `index.ts` — 퍼블릭 API 재노출

## 🗨️ 논의 사항 (참고 사항)

- 웹의 `server.ts`(Next.js ISR/SSG 전용)는 모바일에 해당 없어 제외.
- 웹의 `ui/EpigramListCard`는 웹 전용 Tailwind/`next/image` 기반이라 **이 PR에서 제외** — 모바일 EpigramCard는 별도 widget PR에서 NativeWind + lucide + Pressable로 재작성 예정.
- `keyword` 기반 검색과 일반 목록을 분리된 훅으로 유지한 이유는 웹과 동일: 검색 전용 queryKey를 분리해 캐시 충돌 방지 + `enabled` 처리 간결화.
- 모든 응답은 Zod `.parse()`로 런타임 검증 (백엔드 변경 시 조기 감지).

## 기대효과

- 에피그램 목록·검색·상세·생성·오늘 글 API가 모바일에서 타입 안전하게 사용 가능
- 이후 피드 화면은 `useEpigrams()` 호출 한 줄로 무한 스크롤 구현 가능

Closes #11
