### PR TITLE
feat: entities/comment + emotion-log 스키마·API 훅 이식 (#13)

### DIFF
--- a/src/entities/comment/api/useEpigramComments.ts
+++ b/src/entities/comment/api/useEpigramComments.ts
@@ -1,0 +1,36 @@
+import {
+  useInfiniteQuery,
+  type InfiniteData,
+  type UseInfiniteQueryResult,
+} from "@tanstack/react-query";
+
+import { apiClient } from "~/shared/api/client";
+
+import { commentListResponseSchema, type CommentListResponse } from "../model/schema";
+
+interface UseEpigramCommentsParams {
+  epigramId: number;
+  limit: number;
+}
+
+export function useEpigramComments({
+  epigramId,
+  limit,
+}: UseEpigramCommentsParams): UseInfiniteQueryResult<
+  InfiniteData<CommentListResponse, number | undefined>,
+  Error
+> {
+  return useInfiniteQuery({
+    queryKey: ["epigrams", epigramId, "comments", { limit }],
+    enabled: epigramId > 0,
+    queryFn: async ({ pageParam }) => {
+      const params = new URLSearchParams({ limit: String(limit) });
+      if (pageParam !== undefined) params.set("cursor", String(pageParam));
+
+      const response = await apiClient.get<unknown>(`/epigrams/${epigramId}/comments?${params}`);
+      return commentListResponseSchema.parse(response.data);
+    },
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+  });
+}

--- a/src/entities/comment/api/useMyComments.ts
+++ b/src/entities/comment/api/useMyComments.ts
@@ -1,0 +1,36 @@
+import {
+  useInfiniteQuery,
+  type InfiniteData,
+  type UseInfiniteQueryResult,
+} from "@tanstack/react-query";
+
+import { apiClient } from "~/shared/api/client";
+
+import { commentListResponseSchema, type CommentListResponse } from "../model/schema";
+
+interface UseMyCommentsParams {
+  userId: number;
+  limit: number;
+}
+
+export function useMyComments({
+  userId,
+  limit,
+}: UseMyCommentsParams): UseInfiniteQueryResult<
+  InfiniteData<CommentListResponse, number | undefined>,
+  Error
+> {
+  return useInfiniteQuery({
+    queryKey: ["users", userId, "comments", { limit }],
+    enabled: userId > 0,
+    queryFn: async ({ pageParam }) => {
+      const params = new URLSearchParams({ limit: String(limit) });
+      if (pageParam !== undefined) params.set("cursor", String(pageParam));
+
+      const response = await apiClient.get<unknown>(`/users/${userId}/comments?${params}`);
+      return commentListResponseSchema.parse(response.data);
+    },
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+  });
+}

--- a/src/entities/comment/api/useRecentComments.ts
+++ b/src/entities/comment/api/useRecentComments.ts
@@ -1,0 +1,33 @@
+import {
+  useInfiniteQuery,
+  type InfiniteData,
+  type UseInfiniteQueryResult,
+} from "@tanstack/react-query";
+
+import { apiClient } from "~/shared/api/client";
+
+import { commentListResponseSchema, type CommentListResponse } from "../model/schema";
+
+interface UseRecentCommentsParams {
+  limit: number;
+}
+
+export function useRecentComments({
+  limit,
+}: UseRecentCommentsParams): UseInfiniteQueryResult<
+  InfiniteData<CommentListResponse, number | undefined>,
+  Error
+> {
+  return useInfiniteQuery({
+    queryKey: ["comments", { limit }],
+    queryFn: async ({ pageParam }) => {
+      const params = new URLSearchParams({ limit: String(limit) });
+      if (pageParam !== undefined) params.set("cursor", String(pageParam));
+
+      const response = await apiClient.get<unknown>(`/comments?${params}`);
+      return commentListResponseSchema.parse(response.data);
+    },
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+  });
+}

--- a/src/entities/comment/index.ts
+++ b/src/entities/comment/index.ts
@@ -1,0 +1,6 @@
+export { commentListResponseSchema, commentSchema, writerSchema } from "./model/schema";
+export type { Comment, CommentListResponse, Writer } from "./model/schema";
+
+export { useEpigramComments } from "./api/useEpigramComments";
+export { useMyComments } from "./api/useMyComments";
+export { useRecentComments } from "./api/useRecentComments";

--- a/src/entities/comment/model/schema.ts
+++ b/src/entities/comment/model/schema.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+import { buildPaginatedSchema } from "~/shared/types/pagination";
+
+export const writerSchema = z.object({
+  id: z.number().int().positive(),
+  nickname: z.string(),
+  image: z.string().nullable(),
+});
+
+export const commentSchema = z.object({
+  id: z.number().int().positive(),
+  epigramId: z.number().int().positive(),
+  writer: writerSchema,
+  isPrivate: z.boolean(),
+  content: z.string(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export const commentListResponseSchema = buildPaginatedSchema(commentSchema);
+
+export type Writer = z.infer<typeof writerSchema>;
+export type Comment = z.infer<typeof commentSchema>;
+export type CommentListResponse = z.infer<typeof commentListResponseSchema>;

--- a/src/entities/emotion-log/api/postTodayEmotion.ts
+++ b/src/entities/emotion-log/api/postTodayEmotion.ts
@@ -1,0 +1,8 @@
+import { apiClient } from "~/shared/api/client";
+
+import { emotionLogSchema, type Emotion, type EmotionLog } from "../model/schema";
+
+export async function postTodayEmotion(emotion: Emotion): Promise<EmotionLog> {
+  const response = await apiClient.post<unknown>("/emotionLogs/today", { emotion });
+  return emotionLogSchema.parse(response.data);
+}

--- a/src/entities/emotion-log/api/useMonthlyEmotions.ts
+++ b/src/entities/emotion-log/api/useMonthlyEmotions.ts
@@ -1,0 +1,28 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { apiClient } from "~/shared/api/client";
+
+import { emotionLogArraySchema, type EmotionLog } from "../model/schema";
+
+interface UseMonthlyEmotionsParams {
+  userId: number;
+  year: number;
+  month: number;
+}
+
+export function useMonthlyEmotions({
+  userId,
+  year,
+  month,
+}: UseMonthlyEmotionsParams): UseQueryResult<EmotionLog[], Error> {
+  return useQuery({
+    queryKey: ["emotionLogs", "monthly", userId, year, month],
+    enabled: userId > 0,
+    queryFn: async () => {
+      const response = await apiClient.get<unknown>("/emotionLogs/monthly", {
+        params: { userId, year, month },
+      });
+      return emotionLogArraySchema.parse(response.data);
+    },
+  });
+}

--- a/src/entities/emotion-log/api/useTodayEmotion.ts
+++ b/src/entities/emotion-log/api/useTodayEmotion.ts
@@ -1,0 +1,19 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { apiClient } from "~/shared/api/client";
+
+import { emotionLogSchema, type EmotionLog } from "../model/schema";
+
+export function useTodayEmotion(userId: number): UseQueryResult<EmotionLog | null, Error> {
+  return useQuery({
+    queryKey: ["emotionLogs", "today", userId],
+    enabled: userId > 0,
+    queryFn: async () => {
+      const response = await apiClient.get<unknown>("/emotionLogs/today", {
+        params: { userId },
+      });
+      if (response.data == null || typeof response.data !== "object") return null;
+      return emotionLogSchema.parse(response.data);
+    },
+  });
+}

--- a/src/entities/emotion-log/index.ts
+++ b/src/entities/emotion-log/index.ts
@@ -1,0 +1,6 @@
+export { emotionLogArraySchema, emotionLogSchema, emotionSchema } from "./model/schema";
+export type { Emotion, EmotionLog } from "./model/schema";
+
+export { postTodayEmotion } from "./api/postTodayEmotion";
+export { useMonthlyEmotions } from "./api/useMonthlyEmotions";
+export { useTodayEmotion } from "./api/useTodayEmotion";

--- a/src/entities/emotion-log/model/schema.ts
+++ b/src/entities/emotion-log/model/schema.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const emotionSchema = z.enum(["MOVED", "HAPPY", "WORRIED", "SAD", "ANGRY"]);
+
+export const emotionLogSchema = z.object({
+  id: z.number().int().positive(),
+  userId: z.number().int().positive(),
+  emotion: emotionSchema,
+  createdAt: z.string().datetime(),
+});
+
+export const emotionLogArraySchema = z.array(emotionLogSchema);
+
+export type Emotion = z.infer<typeof emotionSchema>;
+export type EmotionLog = z.infer<typeof emotionLogSchema>;


### PR DESCRIPTION
## ✏️ 작업 내용

### entities/comment
- `model/schema.ts` — `writerSchema`, `commentSchema`, `commentListResponseSchema` + 타입 추론
- `api/useRecentComments.ts` — 최근 댓글 무한 스크롤 (`GET /comments`)
- `api/useEpigramComments.ts` — 특정 에피그램 댓글 무한 스크롤 (`GET /epigrams/:id/comments`)
- `api/useMyComments.ts` — 사용자 댓글 무한 스크롤 (`GET /users/:userId/comments`)
- `index.ts` — 퍼블릭 API (UI 컴포넌트 제외)

### entities/emotion-log
- `model/schema.ts` — `emotionSchema` (MOVED/HAPPY/WORRIED/SAD/ANGRY), `emotionLogSchema`, `emotionLogArraySchema`
- `api/useTodayEmotion.ts` — 오늘 감정 조회 (`GET /emotionLogs/today?userId`)
- `api/postTodayEmotion.ts` — 오늘 감정 기록 (`POST /emotionLogs/today`)
- `api/useMonthlyEmotions.ts` — 월별 감정 조회 (`GET /emotionLogs/monthly`)
- `index.ts`

## 🗨️ 논의 사항 (참고 사항)

- 모바일 `apiClient` baseURL이 이미 `${BACKEND}/${TEAM_ID}`이므로 웹에서 사용하던 `/api/` 접두사를 모두 제거했다.
- 경로 별칭 `@/*` → `~/*`로 교체.
- 웹의 `server.ts` (Next.js ISR/SSG 전용)와 UI 컴포넌트 `WriterAvatar`, `UserProfileModal`은 이식에서 제외 — 추후 widget PR에서 모바일용으로 재구현 예정.
- `npx tsc --noEmit` 통과.
- 변경 라인: 10 files · +212.

## 기대효과

댓글·감정 데이터 접근 계층이 모바일에서도 동일한 Zod 검증·React Query 캐싱 규약으로 준비된다. 이후 댓글 섹션·마이페이지 감정 달력 위젯 이식 시 바로 사용할 수 있다.

Closes #13