### PR TITLE
feat: Login 스크린 구현 (#15)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -44,6 +44,7 @@ export default function RootLayout() {
       <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
         <Stack>
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen name="login" options={{ headerShown: false }} />
           <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
         </Stack>
         <StatusBar style="auto" />

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -1,0 +1,3 @@
+import { LoginScreen } from '~/views/login';
+
+export default LoginScreen;

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,0 +1,4 @@
+export { loginSchema } from "./model/loginSchema";
+export type { LoginFormValues } from "./model/loginSchema";
+
+export { LoginForm } from "./ui/LoginForm";

--- a/src/features/auth/model/loginSchema.ts
+++ b/src/features/auth/model/loginSchema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const loginSchema = z.object({
+  email: z.string().min(1, "이메일은 필수 입력입니다.").email("이메일 형식으로 작성해 주세요."),
+  password: z.string().min(1, "비밀번호는 필수 입력입니다."),
+});
+
+export type LoginFormValues = z.infer<typeof loginSchema>;

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -1,0 +1,90 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
+import { router } from "expo-router";
+import type { ReactElement } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { View } from "react-native";
+
+import { signIn } from "~/entities/user";
+import { Button, Input } from "~/shared/ui";
+
+import { loginSchema, type LoginFormValues } from "../model/loginSchema";
+
+const DEFAULT_VALUES: LoginFormValues = { email: "", password: "" };
+
+export function LoginForm(): ReactElement {
+  const queryClient = useQueryClient();
+  const {
+    control,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginFormValues>({
+    resolver: zodResolver(loginSchema),
+    mode: "onBlur",
+    defaultValues: DEFAULT_VALUES,
+  });
+
+  async function onSubmit(data: LoginFormValues): Promise<void> {
+    try {
+      const { user } = await signIn(data);
+      queryClient.setQueryData(["me"], user);
+      router.replace("/(tabs)");
+    } catch {
+      const message = "이메일 혹은 비밀번호를 확인해주세요.";
+      setError("email", { message });
+      setError("password", { message });
+    }
+  }
+
+  return (
+    <View className="w-full gap-5">
+      <View className="gap-[10px]">
+        <Controller
+          control={control}
+          name="email"
+          render={({ field: { onChange, onBlur, value } }) => (
+            <Input
+              value={value}
+              onChangeText={onChange}
+              onBlur={onBlur}
+              placeholder="이메일"
+              keyboardType="email-address"
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoComplete="email"
+              textContentType="emailAddress"
+              returnKeyType="next"
+              accessibilityLabel="이메일"
+              error={errors.email?.message}
+            />
+          )}
+        />
+        <Controller
+          control={control}
+          name="password"
+          render={({ field: { onChange, onBlur, value } }) => (
+            <Input
+              value={value}
+              onChangeText={onChange}
+              onBlur={onBlur}
+              placeholder="비밀번호"
+              secureTextEntry
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoComplete="password"
+              textContentType="password"
+              returnKeyType="done"
+              onSubmitEditing={handleSubmit(onSubmit)}
+              accessibilityLabel="비밀번호"
+              error={errors.password?.message}
+            />
+          )}
+        />
+      </View>
+      <Button onPress={handleSubmit(onSubmit)} isLoading={isSubmitting}>
+        로그인
+      </Button>
+    </View>
+  );
+}

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -1,0 +1,44 @@
+import type { ReactElement, ReactNode } from "react";
+import { ActivityIndicator, Pressable, Text, type PressableProps } from "react-native";
+
+import { cn } from "~/shared/lib/cn";
+
+export interface ButtonProps extends Omit<PressableProps, "children" | "style"> {
+  children: ReactNode;
+  isLoading?: boolean;
+  className?: string;
+  textClassName?: string;
+}
+
+export function Button({
+  children,
+  isLoading = false,
+  disabled,
+  className,
+  textClassName,
+  ...rest
+}: ButtonProps): ReactElement {
+  const isDisabled = disabled || isLoading;
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ disabled: isDisabled, busy: isLoading }}
+      disabled={isDisabled}
+      className={cn(
+        "h-touch-lg items-center justify-center rounded-xl bg-blue-500 active:bg-blue-600",
+        isDisabled && "bg-blue-400",
+        className
+      )}
+      {...rest}
+    >
+      {isLoading ? (
+        <ActivityIndicator color="#ffffff" />
+      ) : (
+        <Text className={cn("font-sans text-base font-semibold text-blue-100", textClassName)}>
+          {children}
+        </Text>
+      )}
+    </Pressable>
+  );
+}

--- a/src/shared/ui/Input.tsx
+++ b/src/shared/ui/Input.tsx
@@ -1,0 +1,50 @@
+import { forwardRef, useState, type ReactElement } from "react";
+import { Text, TextInput, View, type TextInputProps } from "react-native";
+
+import { cn } from "~/shared/lib/cn";
+
+export interface InputProps extends Omit<TextInputProps, "style"> {
+  error?: string;
+  containerClassName?: string;
+  inputClassName?: string;
+}
+
+function InputImpl(
+  { error, containerClassName, inputClassName, onFocus, onBlur, ...rest }: InputProps,
+  ref: React.ForwardedRef<TextInput>
+): ReactElement {
+  const [isFocused, setIsFocused] = useState(false);
+  const hasError = Boolean(error);
+
+  return (
+    <View className={cn("w-full", containerClassName)}>
+      <TextInput
+        ref={ref}
+        placeholderTextColor="#abb8ce"
+        className={cn(
+          "w-full rounded border bg-blue-200 px-4 py-3 font-sans text-base text-black-900",
+          "border-blue-300",
+          isFocused && "border-blue-500",
+          hasError && "border-error",
+          inputClassName
+        )}
+        onFocus={(event) => {
+          setIsFocused(true);
+          onFocus?.(event);
+        }}
+        onBlur={(event) => {
+          setIsFocused(false);
+          onBlur?.(event);
+        }}
+        {...rest}
+      />
+      {hasError && (
+        <Text className="mt-1 font-sans text-xs text-error" accessibilityRole="alert">
+          {error}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+export const Input = forwardRef<TextInput, InputProps>(InputImpl);

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,0 +1,4 @@
+export { Button } from "./Button";
+export type { ButtonProps } from "./Button";
+export { Input } from "./Input";
+export type { InputProps } from "./Input";

--- a/src/views/login/index.ts
+++ b/src/views/login/index.ts
@@ -1,0 +1,1 @@
+export { LoginScreen } from "./ui/LoginScreen";

--- a/src/views/login/ui/LoginScreen.tsx
+++ b/src/views/login/ui/LoginScreen.tsx
@@ -1,0 +1,28 @@
+import type { ReactElement } from "react";
+import { KeyboardAvoidingView, Platform, ScrollView, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { LoginForm } from "~/features/auth";
+
+export function LoginScreen(): ReactElement {
+  return (
+    <SafeAreaView className="flex-1 bg-background">
+      <KeyboardAvoidingView
+        className="flex-1"
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
+        <ScrollView
+          className="flex-1"
+          contentContainerClassName="flex-grow justify-center px-screen-x py-10"
+          keyboardShouldPersistTaps="handled"
+        >
+          <View className="mb-10 items-center gap-2">
+            <Text className="font-serif-bold text-4xl text-blue-800">epigram</Text>
+            <Text className="font-sans text-sm text-black-300">인생 명언을 모아보세요</Text>
+          </View>
+          <LoginForm />
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}


### PR DESCRIPTION
## ✏️ 작업 내용

### shared/ui
- `Input.tsx` — Pretendard 폰트, focus 시 `blue-500` 테두리, 에러 시 `error` 테두리 + 하단 메시지
- `Button.tsx` — `h-touch-lg` 높이, 비활성화 시 `blue-400`, `isLoading` 상태에서 `ActivityIndicator` 렌더링
- `index.ts`

### features/auth
- `model/loginSchema.ts` — 웹과 동일한 이메일·비밀번호 Zod 스키마
- `ui/LoginForm.tsx` — React Hook Form + `zodResolver`, `Controller` 기반 `TextInput` 연동, `signIn()` 호출
- 성공: `queryClient.setQueryData(["me"], user)` → `router.replace("/(tabs)")`
- 실패: `email`/`password` 필드에 "이메일 혹은 비밀번호를 확인해주세요." 에러 설정
- `index.ts`

### views/login
- `ui/LoginScreen.tsx` — `SafeAreaView` + `KeyboardAvoidingView` + `ScrollView`로 폼 레이아웃 구성, 상단 브랜드 로고(`font-serif-bold`) 포함
- `index.ts`

### app 라우팅
- `app/login.tsx` — `LoginScreen` 재노출
- `app/_layout.tsx` — 루트 `Stack`에 `login` 스크린 등록 (`headerShown: false`)

## 🗨️ 논의 사항 (참고 사항)

- Expo Router 타입 정의(`.expo/types/router.d.ts`)가 아직 옛 `(tabs)/explore` 시절의 것이라 `/(tabs)/feeds` 경로는 타입 에러가 난다. `router.replace("/(tabs)")`만 써도 `unstable_settings.initialRouteName = 'feeds'` 설정 덕분에 피드 탭으로 진입한다. 다음 `expo start` 실행 시 타입 파일이 재생성되면 정확한 경로로 교체 가능.
- 카카오 OAuth·게스트 로그인·회원가입 링크는 별도 이슈로 처리 예정.
- `any` 미사용, 모든 최상위 함수에 명시적 반환 타입, `ReactElement` 반환 선언 준수.
- `npx tsc --noEmit` 통과.
- 변경 라인: 10 files · +233.

## 기대효과

엔드투엔드 인증 흐름을 처음으로 화면에서 검증한다. `signIn()` → SecureStore 토큰 저장 → `["me"]` 쿼리 시드 → 탭으로 진입 흐름이 실제 기기에서 확인 가능해진다. 또한 이후 Signup·Profile·Comment 작성 등의 폼에서 재사용할 `Input`/`Button` 기본 블록이 마련된다.

Closes #15