### PR TITLE
feat: Signup 스크린 + 로그인 연결 (#17)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -45,6 +45,7 @@ export default function RootLayout() {
         <Stack>
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
           <Stack.Screen name="login" options={{ headerShown: false }} />
+          <Stack.Screen name="signup" options={{ headerShown: false }} />
           <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
         </Stack>
         <StatusBar style="auto" />

--- a/app/signup.tsx
+++ b/app/signup.tsx
@@ -1,0 +1,3 @@
+import { SignUpScreen } from '~/views/signup';
+
+export default SignUpScreen;

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,4 +1,7 @@
 export { loginSchema } from "./model/loginSchema";
 export type { LoginFormValues } from "./model/loginSchema";
+export { signUpSchema } from "./model/signUpSchema";
+export type { SignUpFormValues } from "./model/signUpSchema";
 
 export { LoginForm } from "./ui/LoginForm";
+export { SignUpForm } from "./ui/SignUpForm";

--- a/src/features/auth/model/signUpSchema.ts
+++ b/src/features/auth/model/signUpSchema.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const signUpSchema = z
+  .object({
+    email: z.string().min(1, "이메일은 필수 입력입니다.").email("이메일 형식으로 작성해 주세요."),
+    nickname: z
+      .string()
+      .min(1, "닉네임은 필수 입력입니다.")
+      .max(20, "닉네임은 최대 20자까지 가능합니다."),
+    password: z.string().min(8, "비밀번호는 최소 8자 이상입니다."),
+    passwordConfirmation: z.string().min(1, "비밀번호 확인은 필수 입력입니다."),
+  })
+  .refine((data) => data.password === data.passwordConfirmation, {
+    message: "비밀번호가 일치하지 않습니다.",
+    path: ["passwordConfirmation"],
+  });
+
+export type SignUpFormValues = z.infer<typeof signUpSchema>;

--- a/src/features/auth/ui/SignUpForm.tsx
+++ b/src/features/auth/ui/SignUpForm.tsx
@@ -1,0 +1,136 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
+import { router } from "expo-router";
+import type { ReactElement } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { View } from "react-native";
+
+import { signUp } from "~/entities/user";
+import { Button, Input } from "~/shared/ui";
+
+import { signUpSchema, type SignUpFormValues } from "../model/signUpSchema";
+
+const DEFAULT_VALUES: SignUpFormValues = {
+  email: "",
+  nickname: "",
+  password: "",
+  passwordConfirmation: "",
+};
+
+export function SignUpForm(): ReactElement {
+  const queryClient = useQueryClient();
+  const {
+    control,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm<SignUpFormValues>({
+    resolver: zodResolver(signUpSchema),
+    mode: "onBlur",
+    defaultValues: DEFAULT_VALUES,
+  });
+
+  async function onSubmit(data: SignUpFormValues): Promise<void> {
+    try {
+      const { user } = await signUp(data);
+      queryClient.setQueryData(["me"], user);
+      router.replace("/(tabs)");
+    } catch (error) {
+      if (isAxiosError(error) && error.response?.status === 500) {
+        setError("nickname", { message: "이미 사용 중인 닉네임입니다." });
+        return;
+      }
+      setError("email", { message: "회원가입에 실패했습니다. 다시 시도해주세요." });
+    }
+  }
+
+  return (
+    <View className="w-full gap-5">
+      <View className="gap-[10px]">
+        <Controller
+          control={control}
+          name="email"
+          render={({ field: { onChange, onBlur, value } }) => (
+            <Input
+              value={value}
+              onChangeText={onChange}
+              onBlur={onBlur}
+              placeholder="이메일"
+              keyboardType="email-address"
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoComplete="email"
+              textContentType="emailAddress"
+              returnKeyType="next"
+              accessibilityLabel="이메일"
+              error={errors.email?.message}
+            />
+          )}
+        />
+        <Controller
+          control={control}
+          name="nickname"
+          render={({ field: { onChange, onBlur, value } }) => (
+            <Input
+              value={value}
+              onChangeText={onChange}
+              onBlur={onBlur}
+              placeholder="닉네임"
+              autoCapitalize="none"
+              autoCorrect={false}
+              maxLength={20}
+              returnKeyType="next"
+              accessibilityLabel="닉네임"
+              error={errors.nickname?.message}
+            />
+          )}
+        />
+        <Controller
+          control={control}
+          name="password"
+          render={({ field: { onChange, onBlur, value } }) => (
+            <Input
+              value={value}
+              onChangeText={onChange}
+              onBlur={onBlur}
+              placeholder="비밀번호 (최소 8자)"
+              secureTextEntry
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoComplete="new-password"
+              textContentType="newPassword"
+              returnKeyType="next"
+              accessibilityLabel="비밀번호"
+              error={errors.password?.message}
+            />
+          )}
+        />
+        <Controller
+          control={control}
+          name="passwordConfirmation"
+          render={({ field: { onChange, onBlur, value } }) => (
+            <Input
+              value={value}
+              onChangeText={onChange}
+              onBlur={onBlur}
+              placeholder="비밀번호 확인"
+              secureTextEntry
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoComplete="new-password"
+              textContentType="newPassword"
+              returnKeyType="done"
+              onSubmitEditing={handleSubmit(onSubmit)}
+              accessibilityLabel="비밀번호 확인"
+              error={errors.passwordConfirmation?.message}
+            />
+          )}
+        />
+      </View>
+      <Button onPress={handleSubmit(onSubmit)} isLoading={isSubmitting}>
+        가입하기
+      </Button>
+    </View>
+  );
+}

--- a/src/views/signup/index.ts
+++ b/src/views/signup/index.ts
@@ -1,0 +1,1 @@
+export { SignUpScreen } from "./ui/SignUpScreen";

--- a/src/views/signup/ui/SignUpScreen.tsx
+++ b/src/views/signup/ui/SignUpScreen.tsx
@@ -3,11 +3,11 @@ import type { ReactElement } from "react";
 import { KeyboardAvoidingView, Platform, Pressable, ScrollView, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-import { LoginForm } from "~/features/auth";
+import { SignUpForm } from "~/features/auth";
 
-export function LoginScreen(): ReactElement {
-  function handleGoToSignUp(): void {
-    router.push("/signup");
+export function SignUpScreen(): ReactElement {
+  function handleGoToLogin(): void {
+    router.replace("/login");
   }
 
   return (
@@ -23,13 +23,13 @@ export function LoginScreen(): ReactElement {
         >
           <View className="mb-10 items-center gap-2">
             <Text className="font-serif-bold text-4xl text-blue-800">epigram</Text>
-            <Text className="font-sans text-sm text-black-300">인생 명언을 모아보세요</Text>
+            <Text className="font-sans text-sm text-black-300">회원가입</Text>
           </View>
-          <LoginForm />
+          <SignUpForm />
           <View className="mt-6 flex-row justify-center gap-1">
-            <Text className="font-sans text-sm text-black-300">아직 회원이 아니신가요?</Text>
-            <Pressable onPress={handleGoToSignUp} accessibilityRole="link">
-              <Text className="font-sans text-sm font-semibold text-blue-600">회원가입</Text>
+            <Text className="font-sans text-sm text-black-300">이미 회원이신가요?</Text>
+            <Pressable onPress={handleGoToLogin} accessibilityRole="link">
+              <Text className="font-sans text-sm font-semibold text-blue-600">로그인</Text>
             </Pressable>
           </View>
         </ScrollView>


### PR DESCRIPTION
## ✏️ 작업 내용

### features/auth
- `model/signUpSchema.ts` — 웹과 동일한 4필드 Zod 스키마 + `.refine`으로 비밀번호 일치 검증
- `ui/SignUpForm.tsx` — React Hook Form + `zodResolver`, `Controller` 4개
  - 성공: `signUp()` → `queryClient.setQueryData(["me"], user)` → `router.replace("/(tabs)")`
  - 닉네임 중복(HTTP 500): `setError("nickname", { message: "이미 사용 중인 닉네임입니다." })`
  - 기타 에러: email 필드에 "회원가입에 실패했습니다. 다시 시도해주세요." fallback
- `index.ts`에 스키마·컴포넌트 재노출 추가

### views/signup
- `ui/SignUpScreen.tsx` — LoginScreen과 동일한 레이아웃(SafeArea + KeyboardAvoiding + ScrollView) + 하단 "로그인" 링크
- `index.ts`

### views/login 수정
- 하단에 "아직 회원이 아니신가요? 회원가입" 링크 추가 → `router.push("/signup")`

### app 라우팅
- `app/signup.tsx` — `SignUpScreen` 재노출
- `app/_layout.tsx` — 루트 `Stack`에 `signup` 등록 (`headerShown: false`)

## 🗨️ 논의 사항 (참고 사항)

- 스테일된 `.expo/types/router.d.ts`(gitignore 대상)를 삭제하여 타입 체크 통과. 다음 `expo start` 시 현재 라우트 셋으로 자동 재생성됨.
- 카카오 OAuth 버튼은 Expo 딥링킹(URL scheme, `expo-web-browser` 또는 `expo-auth-session`) 설계가 필요해 별도 이슈로 분리.
- 프로필 이미지 업로드는 마이페이지 수정 기능과 묶어 추후 진행.
- `any` 미사용, `ReactElement` 반환 타입 명시, Guard clause(`return` in catch) 적용.
- `npx tsc --noEmit` 통과.
- 변경 라인: 8 files · +213 / −1.

## 기대효과

이메일 회원가입 end-to-end 흐름이 완성되어 로그인/가입 간 자연스러운 이동이 가능해진다. `signUp()` → 토큰 SecureStore 저장 → 자동 로그인 → 탭 진입이 한 화면에서 검증된다. `Input`/`Button` 공용 컴포넌트의 두 번째 사용처로서 재사용성도 함께 확인된다.

Closes #17