### PR TITLE
feat: Epigram 카드 위젯 + feeds 탭 실렌더링 (#19)

### DIFF
--- a/app/(tabs)/feeds.tsx
+++ b/app/(tabs)/feeds.tsx
@@ -1,13 +1,11 @@
-import { Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { EpigramFeed } from '~/widgets/epigram-feed';
 
 export default function FeedsScreen() {
   return (
-    <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 items-center justify-center px-screen-x">
-        <Text className="font-sans text-2xl font-bold text-black-900">피드</Text>
-        <Text className="mt-2 font-sans text-sm text-blue-400">에피그램 목록이 여기에 표시됩니다</Text>
-      </View>
+    <SafeAreaView className="flex-1 bg-background" edges={['top']}>
+      <EpigramFeed />
     </SafeAreaView>
   );
 }

--- a/app/modal.tsx
+++ b/app/modal.tsx
@@ -8,7 +8,7 @@ export default function ModalScreen() {
   return (
     <ThemedView style={styles.container}>
       <ThemedText type="title">This is a modal</ThemedText>
-      <Link href="/" dismissTo style={styles.link}>
+      <Link href="/feeds" dismissTo style={styles.link}>
         <ThemedText type="link">Go to home screen</ThemedText>
       </Link>
     </ThemedView>

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -29,7 +29,7 @@ export function LoginForm(): ReactElement {
     try {
       const { user } = await signIn(data);
       queryClient.setQueryData(["me"], user);
-      router.replace("/(tabs)");
+      router.replace("/feeds");
     } catch {
       const message = "이메일 혹은 비밀번호를 확인해주세요.";
       setError("email", { message });

--- a/src/features/auth/ui/SignUpForm.tsx
+++ b/src/features/auth/ui/SignUpForm.tsx
@@ -35,7 +35,7 @@ export function SignUpForm(): ReactElement {
     try {
       const { user } = await signUp(data);
       queryClient.setQueryData(["me"], user);
-      router.replace("/(tabs)");
+      router.replace("/feeds");
     } catch (error) {
       if (isAxiosError(error) && error.response?.status === 500) {
         setError("nickname", { message: "이미 사용 중인 닉네임입니다." });

--- a/src/widgets/epigram-card/index.ts
+++ b/src/widgets/epigram-card/index.ts
@@ -1,0 +1,1 @@
+export { EpigramCard } from "./ui/EpigramCard";

--- a/src/widgets/epigram-card/ui/EpigramCard.tsx
+++ b/src/widgets/epigram-card/ui/EpigramCard.tsx
@@ -1,0 +1,47 @@
+import { memo, type ReactElement } from "react";
+import { Pressable, Text, View } from "react-native";
+
+import type { Epigram } from "~/entities/epigram";
+
+interface EpigramCardProps {
+  epigram: Epigram;
+  onPress?: (epigramId: number) => void;
+}
+
+function EpigramCardBase({ epigram, onPress }: EpigramCardProps): ReactElement {
+  function handlePress(): void {
+    onPress?.(epigram.id);
+  }
+
+  return (
+    <View className="w-full gap-2">
+      <Pressable
+        onPress={handlePress}
+        accessibilityRole="button"
+        accessibilityLabel={`에피그램: ${epigram.content}`}
+        className="w-full rounded-2xl border border-line-100 bg-surface p-6 shadow-card active:bg-blue-200"
+      >
+        <View className="gap-5">
+          <Text className="font-serif text-base leading-relaxed text-black-600">
+            {epigram.content}
+          </Text>
+          <Text className="text-right font-serif text-base text-blue-400">
+            - {epigram.author} -
+          </Text>
+        </View>
+      </Pressable>
+
+      {epigram.tags.length > 0 && (
+        <View className="flex-row flex-wrap justify-end gap-3">
+          {epigram.tags.map((tag) => (
+            <Text key={tag.id} className="font-serif text-sm text-blue-400">
+              #{tag.name}
+            </Text>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
+
+export const EpigramCard = memo(EpigramCardBase);

--- a/src/widgets/epigram-feed/index.ts
+++ b/src/widgets/epigram-feed/index.ts
@@ -1,0 +1,1 @@
+export { EpigramFeed } from "./ui/EpigramFeed";

--- a/src/widgets/epigram-feed/ui/EpigramFeed.tsx
+++ b/src/widgets/epigram-feed/ui/EpigramFeed.tsx
@@ -1,0 +1,80 @@
+import { useCallback, type ReactElement } from "react";
+import { ActivityIndicator, FlatList, Text, View, type ListRenderItem } from "react-native";
+
+import { useEpigrams, type Epigram } from "~/entities/epigram";
+import { EpigramCard } from "~/widgets/epigram-card";
+
+const FEED_PAGE_SIZE = 10;
+
+function ItemSeparator(): ReactElement {
+  return <View className="h-6" />;
+}
+
+function LoadingState(): ReactElement {
+  return (
+    <View className="flex-1 items-center justify-center py-10">
+      <ActivityIndicator color="#6a82a9" />
+    </View>
+  );
+}
+
+function EmptyState(): ReactElement {
+  return (
+    <View className="flex-1 items-center justify-center py-20">
+      <Text className="font-serif text-base text-black-300">등록된 에피그램이 없습니다</Text>
+      <Text className="mt-2 font-sans text-sm text-blue-400">첫 번째 에피그램을 작성해 보세요</Text>
+    </View>
+  );
+}
+
+function ErrorState({ message }: { message: string }): ReactElement {
+  return (
+    <View className="flex-1 items-center justify-center py-20">
+      <Text className="font-sans text-base text-error">{message}</Text>
+    </View>
+  );
+}
+
+function FooterLoader({ visible }: { visible: boolean }): ReactElement | null {
+  if (!visible) return null;
+  return (
+    <View className="items-center py-6">
+      <ActivityIndicator color="#6a82a9" />
+    </View>
+  );
+}
+
+export function EpigramFeed(): ReactElement {
+  const { data, isLoading, isError, isFetchingNextPage, hasNextPage, fetchNextPage } = useEpigrams({
+    limit: FEED_PAGE_SIZE,
+  });
+
+  const epigrams = data?.pages.flatMap((page) => page.list) ?? [];
+
+  const renderItem = useCallback<ListRenderItem<Epigram>>(
+    ({ item }) => <EpigramCard epigram={item} />,
+    []
+  );
+
+  function handleEndReached(): void {
+    if (!hasNextPage || isFetchingNextPage) return;
+    fetchNextPage();
+  }
+
+  if (isLoading) return <LoadingState />;
+  if (isError) return <ErrorState message="에피그램을 불러오지 못했습니다" />;
+
+  return (
+    <FlatList
+      data={epigrams}
+      keyExtractor={(item) => String(item.id)}
+      renderItem={renderItem}
+      ItemSeparatorComponent={ItemSeparator}
+      ListEmptyComponent={EmptyState}
+      ListFooterComponent={<FooterLoader visible={isFetchingNextPage} />}
+      onEndReached={handleEndReached}
+      onEndReachedThreshold={0.3}
+      contentContainerClassName="px-screen-x py-6"
+    />
+  );
+}


### PR DESCRIPTION
## ✏️ 작업 내용

### widgets/epigram-card
- `ui/EpigramCard.tsx` — 본문·작성자·태그를 표시하는 `Pressable` 카드
  - 본문·작성자: NanumMyeongjo(`font-serif`), 태그: `#tagname` 형태로 우측 정렬
  - `React.memo`로 감싸 리스트 재렌더링 최소화
  - 선택적 `onPress(epigramId)` 콜백 (상세 페이지 연결은 후속 이슈)
- `index.ts`

### widgets/epigram-feed
- `ui/EpigramFeed.tsx` — `FlatList` + `useEpigrams({ limit: 10 })` 무한 스크롤
  - `onEndReached` → `hasNextPage && !isFetchingNextPage` 가드 후 `fetchNextPage()`
  - 초기 로딩(`ActivityIndicator`), 에러, 빈 상태를 별도 컴포넌트로 분기
  - `ListFooterComponent`에서 다음 페이지 로딩 인디케이터 노출
- `index.ts`

### feeds 탭 연결
- `app/(tabs)/feeds.tsx` — 플레이스홀더(`"피드"` 텍스트) 제거, `<EpigramFeed />` 렌더

### 타입드 라우트 대응
- Expo Router가 현재 라우트 셋(`/feeds`, `/search`, `/addepigram`, `/mypage`, `/login`, `/signup`, `/modal`)으로 타입을 재생성했고, `(tabs)` 그룹 단독 루트는 더 이상 유효하지 않음
  - `router.replace("/(tabs)")` → `router.replace("/feeds")` (Login/SignUp 폼)
  - `<Link href="/" />` → `<Link href="/feeds" />` (Expo 템플릿 잔존 `modal.tsx`)

## 🗨️ 논의 사항 (참고 사항)

- 카드 탭 → 상세 페이지 이동, 오늘의 에피그램 섹션, 좋아요 버튼은 각각 별도 이슈로 분리.
- `modal.tsx`는 Expo 템플릿 잔존 파일이라 장기적으로 제거 대상이지만 이번 PR 범위 밖. 타입 에러만 최소 패치.
- `npx tsc --noEmit` 통과.
- 변경 라인: 8 files · +136 / −9.

## 기대효과

에피그램 API → Zod 검증 → React Query 캐싱 → FlatList 렌더링의 end-to-end 파이프라인이 실기기에서 검증 가능해진다. 이후 추가될 카드 상세, 좋아요, 댓글 등 기능들이 동일한 카드·피드 구조 위에서 전개된다.

Closes #19