### PR TITLE
fix: 루트 경로(/) 진입 시 인증 상태 기반 리다이렉트

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,20 @@
+import { Redirect } from "expo-router";
+import type { ReactElement } from "react";
+import { ActivityIndicator, View } from "react-native";
+
+import { useMe } from "~/entities/user";
+
+export default function IndexScreen(): ReactElement {
+  const { user, isLoading } = useMe();
+
+  if (isLoading) {
+    return (
+      <View className="flex-1 items-center justify-center bg-background">
+        <ActivityIndicator color="#6a82a9" />
+      </View>
+    );
+  }
+
+  if (user) return <Redirect href="/feeds" />;
+  return <Redirect href="/login" />;
+}


### PR DESCRIPTION
Closes #21

## 변경 사항

- `app/index.tsx` 신규 추가
  - `useMe`로 인증 상태 확인 후 `<Redirect />`로 분기
    - 로그인 상태 → `/feeds`
    - 비로그인 상태 → `/login`
    - 로딩 중 → 중앙 정렬된 `ActivityIndicator`

## 배경

`app/` 하위에 `index.tsx`가 없고 `(tabs)/index.tsx`도 없어서 웹/딥링크로 `/`에 접근하면 Expo Router가 "Unmatched Route" 화면을 표시했다. 네이티브 실행 시에는 Stack anchor 동작 덕분에 드러나지 않던 문제였다.

## 테스트 계획

- [ ] 로그인 상태에서 `http://localhost:8081` → `/feeds`로 이동
- [ ] 비로그인 상태에서 `http://localhost:8081` → `/login`으로 이동
- [ ] 로딩 중 스피너 표시 확인
