### PR TITLE
fix: 웹 라우트 보호 구조와 일치 — 피드 공개 + 인증 페이지 가드

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,20 +1,6 @@
 import { Redirect } from "expo-router";
 import type { ReactElement } from "react";
-import { ActivityIndicator, View } from "react-native";
-
-import { useMe } from "~/entities/user";
 
 export default function IndexScreen(): ReactElement {
-  const { user, isLoading } = useMe();
-
-  if (isLoading) {
-    return (
-      <View className="flex-1 items-center justify-center bg-background">
-        <ActivityIndicator color="#6a82a9" />
-      </View>
-    );
-  }
-
-  if (user) return <Redirect href="/feeds" />;
-  return <Redirect href="/login" />;
+  return <Redirect href="/feeds" />;
 }

--- a/src/views/login/ui/LoginScreen.tsx
+++ b/src/views/login/ui/LoginScreen.tsx
@@ -1,11 +1,17 @@
-import { router } from "expo-router";
+import { Redirect, router } from "expo-router";
 import type { ReactElement } from "react";
 import { KeyboardAvoidingView, Platform, Pressable, ScrollView, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
+import { useMe } from "~/entities/user";
 import { LoginForm } from "~/features/auth";
 
-export function LoginScreen(): ReactElement {
+export function LoginScreen(): ReactElement | null {
+  const { user, isLoading } = useMe();
+
+  if (isLoading) return null;
+  if (user) return <Redirect href="/feeds" />;
+
   function handleGoToSignUp(): void {
     router.push("/signup");
   }

--- a/src/views/signup/ui/SignUpScreen.tsx
+++ b/src/views/signup/ui/SignUpScreen.tsx
@@ -1,11 +1,17 @@
-import { router } from "expo-router";
+import { Redirect, router } from "expo-router";
 import type { ReactElement } from "react";
 import { KeyboardAvoidingView, Platform, Pressable, ScrollView, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
+import { useMe } from "~/entities/user";
 import { SignUpForm } from "~/features/auth";
 
-export function SignUpScreen(): ReactElement {
+export function SignUpScreen(): ReactElement | null {
+  const { user, isLoading } = useMe();
+
+  if (isLoading) return null;
+  if (user) return <Redirect href="/feeds" />;
+
   function handleGoToLogin(): void {
     router.replace("/login");
   }


### PR DESCRIPTION
Closes #23

## 변경 사항

- `app/index.tsx` — 인증 체크 제거, 무조건 `/feeds`로 리다이렉트
- `LoginScreen`, `SignUpScreen` — 이미 로그인된 상태라면 `/feeds`로 리다이렉트 (웹의 `AUTH_ONLY_PATHS` 가드와 동일)
  - `isLoading` 중: `null` 반환 (폼 flash 방지)
  - `user` 존재: `<Redirect href="/feeds" />`

## 배경

웹 미들웨어는 `/feeds`, `/epigrams` 목록, `/search`를 비회원에게도 허용한다. 모바일도 동일한 정책을 따라 콘텐츠 탐색 장벽을 낮춘다. 상세페이지(`/epigrams/[id]`) 등 로그인 필요 경로 보호는 해당 화면 구현 시 함께 처리한다.

## 테스트 계획

- [ ] 비로그인 상태 `/` 접근 → `/feeds` 렌더링
- [ ] 로그인 상태 `/login` 직접 접근 → `/feeds`로 이동
- [ ] 로그인 상태 `/signup` 직접 접근 → `/feeds`로 이동
- [ ] 로그인 플로우 정상 동작 (기존 회귀 없음)
