### PR TITLE
fix: 탭바 아이콘 위치 상향 조정

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -32,7 +32,7 @@ export default function TabLayout(): ReactElement {
         tabBarActiveTintColor: '#454545',
         tabBarInactiveTintColor: '#abb8ce',
         tabBarLabelStyle: { fontFamily: 'Pretendard', fontSize: 12 },
-        tabBarStyle: { height: 64, paddingBottom: 8, paddingTop: 8 },
+        tabBarStyle: { height: 64, paddingBottom: 4, paddingTop: 12 },
       }}
     >
       <Tabs.Screen


### PR DESCRIPTION
Closes #25

## 변경 사항

- [app/(tabs)/_layout.tsx](app/(tabs)/_layout.tsx) — `tabBarStyle` padding 조정
  - `paddingTop: 8 → 12`
  - `paddingBottom: 8 → 4`

## 배경

기기 하단 safe area inset이 자동 추가되는 상태에서 `paddingBottom: 8`이 과해 아이콘이 시각적으로 낮게 쏠려 보였다. 상하 패딩 균형을 조정해 아이콘을 위로 올린다.

## 테스트 계획

- [ ] 실기기에서 탭바 아이콘이 이전보다 위쪽에 위치
- [ ] 라벨(피드/검색/마이) 잘림 없음
- [ ] 중앙 추가 버튼(`-top-2`)과 시각적 균형 유지
