### PR TITLE
style: 에피그램 카드에 줄무늬 배경 추가

### DIFF
--- a/src/widgets/epigram-card/ui/EpigramCard.tsx
+++ b/src/widgets/epigram-card/ui/EpigramCard.tsx
@@ -1,11 +1,35 @@
 import { memo, type ReactElement } from "react";
-import { Pressable, Text, View } from "react-native";
+import { Pressable, StyleSheet, Text, View } from "react-native";
 
 import type { Epigram } from "~/entities/epigram";
 
 interface EpigramCardProps {
   epigram: Epigram;
   onPress?: (epigramId: number) => void;
+}
+
+const RULE_LINE_SPACING = 24;
+const RULE_LINE_COUNT = 20;
+const RULE_LINE_COLOR = "#f2f2f2";
+
+function RuledLines(): ReactElement {
+  return (
+    <View pointerEvents="none" style={StyleSheet.absoluteFill}>
+      {Array.from({ length: RULE_LINE_COUNT }).map((_, index) => (
+        <View
+          key={index}
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            top: (index + 1) * RULE_LINE_SPACING,
+            height: 1,
+            backgroundColor: RULE_LINE_COLOR,
+          }}
+        />
+      ))}
+    </View>
+  );
 }
 
 function EpigramCardBase({ epigram, onPress }: EpigramCardProps): ReactElement {
@@ -19,8 +43,9 @@ function EpigramCardBase({ epigram, onPress }: EpigramCardProps): ReactElement {
         onPress={handlePress}
         accessibilityRole="button"
         accessibilityLabel={`에피그램: ${epigram.content}`}
-        className="w-full rounded-2xl border border-line-100 bg-surface p-6 shadow-card active:bg-blue-200"
+        className="w-full overflow-hidden rounded-2xl border border-line-100 bg-surface p-6 shadow-card active:bg-blue-200"
       >
+        <RuledLines />
         <View className="gap-5">
           <Text className="font-serif text-base leading-relaxed text-black-600">
             {epigram.content}


### PR DESCRIPTION
Closes #27

## 변경 사항

- [src/widgets/epigram-card/ui/EpigramCard.tsx](src/widgets/epigram-card/ui/EpigramCard.tsx)
  - `RuledLines` 컴포넌트 추가 — 24px 간격 가로선 20줄을 절대 위치로 렌더링
  - `Pressable`에 `overflow-hidden` 추가 — 둥근 모서리 바깥 영역 차단
  - `RuledLines`를 `Pressable`의 첫 번째 자식으로 배치 (z-order: 본문이 위에 위치)
  - `pointerEvents="none"`으로 카드 탭 인터랙션 보존

## 배경

웹의 `EpigramListCard`는 `repeating-linear-gradient`로 노트 느낌의 줄무늬 배경을 구현한다. RN은 CSS gradient 미지원이라 절대 위치 `View`로 동일한 효과를 재현했다. 색상·간격 모두 웹과 일치한다 (`line-100 = #f2f2f2`, 24px 간격).

## 테스트 계획

- [ ] 실기기 카드 배경에 24px 간격 가로선 표시
- [ ] 본문 텍스트가 줄 위에 정상 표시
- [ ] 둥근 모서리 밖으로 선이 튀어나오지 않음
- [ ] 카드 탭 시 `active:bg-blue-200` 배경 변화 동작
