### PR TITLE
style: 탭바 높이·패딩 재조정 및 따옴표 스타일 통일

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,11 +1,11 @@
-import { Tabs } from 'expo-router';
-import { Home, Plus, Search, User } from 'lucide-react-native';
-import { ReactElement } from 'react';
-import { Pressable, View } from 'react-native';
-import type { BottomTabBarButtonProps } from '@react-navigation/bottom-tabs';
+import type { BottomTabBarButtonProps } from "@react-navigation/bottom-tabs";
+import { Tabs } from "expo-router";
+import { Home, Plus, Search, User } from "lucide-react-native";
+import { ReactElement } from "react";
+import { Pressable, View } from "react-native";
 
 export const unstable_settings = {
-  initialRouteName: 'feeds',
+  initialRouteName: "feeds",
 };
 
 function CenterAddButton(props: BottomTabBarButtonProps): ReactElement {
@@ -29,37 +29,37 @@ export default function TabLayout(): ReactElement {
     <Tabs
       screenOptions={{
         headerShown: false,
-        tabBarActiveTintColor: '#454545',
-        tabBarInactiveTintColor: '#abb8ce',
-        tabBarLabelStyle: { fontFamily: 'Pretendard', fontSize: 12 },
-        tabBarStyle: { height: 64, paddingBottom: 4, paddingTop: 12 },
+        tabBarActiveTintColor: "#454545",
+        tabBarInactiveTintColor: "#abb8ce",
+        tabBarLabelStyle: { fontFamily: "Pretendard", fontSize: 12 },
+        tabBarStyle: { height: 80, paddingBottom: 8, paddingTop: 4 },
       }}
     >
       <Tabs.Screen
         name="feeds"
         options={{
-          title: '피드',
+          title: "피드",
           tabBarIcon: ({ color }) => <Home size={24} color={color} />,
         }}
       />
       <Tabs.Screen
         name="search"
         options={{
-          title: '검색',
+          title: "검색",
           tabBarIcon: ({ color }) => <Search size={24} color={color} />,
         }}
       />
       <Tabs.Screen
         name="addepigram"
         options={{
-          title: '',
+          title: "",
           tabBarButton: (props) => <CenterAddButton {...props} />,
         }}
       />
       <Tabs.Screen
         name="mypage"
         options={{
-          title: '마이',
+          title: "마이",
           tabBarIcon: ({ color }) => <User size={24} color={color} />,
         }}
       />


### PR DESCRIPTION
Closes #29

## 변경 사항

- [app/(tabs)/_layout.tsx](app/(tabs)/_layout.tsx)
  - `tabBarStyle`: `height: 64 → 80`, `paddingTop: 12 → 4`, `paddingBottom: 4 → 8`
  - 따옴표 single → double로 파일 전체 통일

## 배경

PR #26에서 패딩만 조정했는데 실기기 검증 결과 바 높이 자체가 부족했다. 높이를 키우고 아래 패딩을 회복해 시각적 안정감을 개선한다.

## 테스트 계획

- [ ] 실기기(Expo Go) 탭바 전체 비율이 개선됨
- [ ] 아이콘·라벨 중앙 정렬 유지
- [ ] 중앙 추가 버튼(`CenterAddButton`) 위치 어긋남 없음
