### PR TITLE
feat: 에피그램 상세 페이지 + 좋아요 토글 (#31)

### DIFF
--- a/app/epigrams/[id].tsx
+++ b/app/epigrams/[id].tsx
@@ -1,0 +1,13 @@
+import { useLocalSearchParams } from "expo-router";
+import type { ReactElement } from "react";
+
+import { EpigramDetailScreen } from "~/views/epigram-detail";
+
+export default function EpigramDetailRoute(): ReactElement | null {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const epigramId = Number(id);
+
+  if (!Number.isInteger(epigramId) || epigramId <= 0) return null;
+
+  return <EpigramDetailScreen epigramId={epigramId} />;
+}

--- a/src/features/epigram-like/index.ts
+++ b/src/features/epigram-like/index.ts
@@ -1,0 +1,2 @@
+export { useEpigramLike } from "./model/useEpigramLike";
+export { LikeButton } from "./ui/LikeButton";

--- a/src/features/epigram-like/model/useEpigramLike.ts
+++ b/src/features/epigram-like/model/useEpigramLike.ts
@@ -1,0 +1,62 @@
+import { useCallback, useMemo } from "react";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import type { EpigramDetail } from "~/entities/epigram";
+import { apiClient } from "~/shared/api/client";
+
+interface UseEpigramLikeReturn {
+  toggle: () => void;
+  isPending: boolean;
+}
+
+export function useEpigramLike(epigramId: number): UseEpigramLikeReturn {
+  const queryClient = useQueryClient();
+  const queryKey = useMemo(() => ["epigrams", epigramId], [epigramId]);
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: async (isCurrentlyLiked: boolean): Promise<EpigramDetail> => {
+      if (isCurrentlyLiked) {
+        const res = await apiClient.delete<EpigramDetail>(
+          `/epigrams/${epigramId}/like`,
+        );
+        return res.data;
+      }
+      const res = await apiClient.post<EpigramDetail>(
+        `/epigrams/${epigramId}/like`,
+      );
+      return res.data;
+    },
+    onMutate: async (isCurrentlyLiked) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<EpigramDetail>(queryKey);
+
+      queryClient.setQueryData<EpigramDetail>(queryKey, (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          isLiked: !old.isLiked,
+          likeCount: isCurrentlyLiked ? old.likeCount - 1 : old.likeCount + 1,
+        };
+      });
+
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKey, context.previous);
+      }
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(queryKey, data);
+    },
+  });
+
+  const toggle = useCallback(() => {
+    const current = queryClient.getQueryData<EpigramDetail>(queryKey);
+    if (!current) return;
+    mutate(current.isLiked);
+  }, [queryClient, queryKey, mutate]);
+
+  return { toggle, isPending };
+}

--- a/src/features/epigram-like/ui/LikeButton.tsx
+++ b/src/features/epigram-like/ui/LikeButton.tsx
@@ -1,0 +1,51 @@
+import { Heart } from "lucide-react-native";
+import type { ReactElement } from "react";
+import { Pressable, Text } from "react-native";
+
+import { cn } from "~/shared/lib/cn";
+
+import { useEpigramLike } from "../model/useEpigramLike";
+
+interface LikeButtonProps {
+  epigramId: number;
+  likeCount: number;
+  isLiked: boolean;
+}
+
+export function LikeButton({
+  epigramId,
+  likeCount,
+  isLiked,
+}: LikeButtonProps): ReactElement {
+  const { toggle, isPending } = useEpigramLike(epigramId);
+
+  return (
+    <Pressable
+      onPress={toggle}
+      disabled={isPending}
+      accessibilityRole="button"
+      accessibilityLabel={isLiked ? "좋아요 취소" : "좋아요"}
+      accessibilityState={{ disabled: isPending, selected: isLiked }}
+      className={cn(
+        "flex-row items-center gap-1.5 self-center rounded-full px-4 py-2",
+        isLiked ? "bg-black-500" : "border border-blue-300 bg-surface",
+        isPending && "opacity-60",
+      )}
+    >
+      <Heart
+        size={16}
+        strokeWidth={2}
+        color={isLiked ? "#ffffff" : "#6a82a9"}
+        fill={isLiked ? "#ffffff" : "transparent"}
+      />
+      <Text
+        className={cn(
+          "font-sans text-sm font-semibold",
+          isLiked ? "text-white" : "text-blue-600",
+        )}
+      >
+        {likeCount}
+      </Text>
+    </Pressable>
+  );
+}

--- a/src/views/epigram-detail/index.ts
+++ b/src/views/epigram-detail/index.ts
@@ -1,0 +1,1 @@
+export { EpigramDetailScreen } from "./ui/EpigramDetailScreen";

--- a/src/views/epigram-detail/ui/EpigramDetailScreen.tsx
+++ b/src/views/epigram-detail/ui/EpigramDetailScreen.tsx
@@ -1,0 +1,180 @@
+import { router } from "expo-router";
+import { ArrowLeft, ExternalLink } from "lucide-react-native";
+import { type ReactElement } from "react";
+import {
+  ActivityIndicator,
+  Linking,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { useEpigramDetail, type EpigramDetail } from "~/entities/epigram";
+import { LikeButton } from "~/features/epigram-like";
+
+interface EpigramDetailScreenProps {
+  epigramId: number;
+}
+
+const RULE_LINE_SPACING = 28;
+const RULE_LINE_COUNT = 24;
+const RULE_LINE_COLOR = "#f2f2f2";
+
+function RuledLines(): ReactElement {
+  return (
+    <View pointerEvents="none" style={StyleSheet.absoluteFill}>
+      {Array.from({ length: RULE_LINE_COUNT }).map((_, index) => (
+        <View
+          key={index}
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            top: (index + 1) * RULE_LINE_SPACING,
+            height: 1,
+            backgroundColor: RULE_LINE_COLOR,
+          }}
+        />
+      ))}
+    </View>
+  );
+}
+
+function BackButton(): ReactElement {
+  function handleBack(): void {
+    if (router.canGoBack()) {
+      router.back();
+      return;
+    }
+    router.replace("/feeds");
+  }
+
+  return (
+    <Pressable
+      onPress={handleBack}
+      accessibilityRole="button"
+      accessibilityLabel="뒤로 가기"
+      className="h-10 w-10 items-center justify-center rounded-full active:bg-blue-200"
+    >
+      <ArrowLeft size={22} color="#454545" />
+    </Pressable>
+  );
+}
+
+function LoadingState(): ReactElement {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <ActivityIndicator color="#6a82a9" />
+    </View>
+  );
+}
+
+function ErrorState(): ReactElement {
+  return (
+    <View className="flex-1 items-center justify-center px-screen-x">
+      <Text className="font-sans text-base text-error">
+        에피그램을 불러오지 못했습니다
+      </Text>
+    </View>
+  );
+}
+
+function Reference({
+  epigram,
+}: {
+  epigram: EpigramDetail;
+}): ReactElement | null {
+  if (!epigram.referenceTitle) return null;
+
+  async function handleOpenReference(): Promise<void> {
+    if (!epigram.referenceUrl) return;
+    await Linking.openURL(epigram.referenceUrl);
+  }
+
+  if (!epigram.referenceUrl) {
+    return (
+      <Text className="text-right font-sans text-xs text-black-300">
+        {epigram.referenceTitle}
+      </Text>
+    );
+  }
+
+  return (
+    <Pressable
+      onPress={handleOpenReference}
+      accessibilityRole="link"
+      accessibilityLabel={`출처 ${epigram.referenceTitle} 열기`}
+      className="flex-row items-center justify-end gap-1 self-end"
+    >
+      <Text className="font-sans text-xs text-blue-500 underline">
+        {epigram.referenceTitle}
+      </Text>
+      <ExternalLink size={12} color="#3b82f6" />
+    </Pressable>
+  );
+}
+
+export function EpigramDetailScreen({
+  epigramId,
+}: EpigramDetailScreenProps): ReactElement {
+  const { data: epigram, isLoading, isError } = useEpigramDetail(epigramId);
+
+  return (
+    <SafeAreaView className="flex-1 bg-background" edges={["top"]}>
+      <View className="flex-row items-center px-screen-x py-2">
+        <BackButton />
+      </View>
+      <ShowContent epigram={epigram} isLoading={isLoading} isError={isError} />
+    </SafeAreaView>
+  );
+}
+
+interface ShowContentProps {
+  epigram: EpigramDetail | undefined;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+function ShowContent({
+  epigram,
+  isLoading,
+  isError,
+}: ShowContentProps): ReactElement {
+  if (isLoading) return <LoadingState />;
+  if (isError || !epigram) return <ErrorState />;
+
+  return (
+    <View className="flex-1 px-screen-x py-4">
+      <View className="w-full overflow-hidden rounded-2xl border border-line-100 bg-surface p-6 shadow-card">
+        <RuledLines />
+        <View className="gap-6">
+          <Text className="font-serif text-lg leading-relaxed text-black-700">
+            {epigram.content}
+          </Text>
+          <Text className="text-right font-serif text-base text-blue-400">
+            - {epigram.author} -
+          </Text>
+          <Reference epigram={epigram} />
+          {epigram.tags.length > 0 && (
+            <View className="flex-row flex-wrap justify-end gap-2">
+              {epigram.tags.map((tag) => (
+                <Text key={tag.id} className="font-serif text-sm text-blue-400">
+                  #{tag.name}
+                </Text>
+              ))}
+            </View>
+          )}
+          <View className="items-center pt-2">
+            <LikeButton
+              epigramId={epigram.id}
+              likeCount={epigram.likeCount}
+              isLiked={epigram.isLiked}
+            />
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/src/widgets/epigram-feed/ui/EpigramFeed.tsx
+++ b/src/widgets/epigram-feed/ui/EpigramFeed.tsx
@@ -1,5 +1,12 @@
+import { router } from "expo-router";
 import { useCallback, type ReactElement } from "react";
-import { ActivityIndicator, FlatList, Text, View, type ListRenderItem } from "react-native";
+import {
+  ActivityIndicator,
+  FlatList,
+  Text,
+  View,
+  type ListRenderItem,
+} from "react-native";
 
 import { useEpigrams, type Epigram } from "~/entities/epigram";
 import { EpigramCard } from "~/widgets/epigram-card";
@@ -21,8 +28,12 @@ function LoadingState(): ReactElement {
 function EmptyState(): ReactElement {
   return (
     <View className="flex-1 items-center justify-center py-20">
-      <Text className="font-serif text-base text-black-300">등록된 에피그램이 없습니다</Text>
-      <Text className="mt-2 font-sans text-sm text-blue-400">첫 번째 에피그램을 작성해 보세요</Text>
+      <Text className="font-serif text-base text-black-300">
+        등록된 에피그램이 없습니다
+      </Text>
+      <Text className="mt-2 font-sans text-sm text-blue-400">
+        첫 번째 에피그램을 작성해 보세요
+      </Text>
     </View>
   );
 }
@@ -45,15 +56,29 @@ function FooterLoader({ visible }: { visible: boolean }): ReactElement | null {
 }
 
 export function EpigramFeed(): ReactElement {
-  const { data, isLoading, isError, isFetchingNextPage, hasNextPage, fetchNextPage } = useEpigrams({
+  const {
+    data,
+    isLoading,
+    isError,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+  } = useEpigrams({
     limit: FEED_PAGE_SIZE,
   });
 
   const epigrams = data?.pages.flatMap((page) => page.list) ?? [];
 
+  const handleCardPress = useCallback((epigramId: number) => {
+    router.push({
+      pathname: "/epigrams/[id]",
+      params: { id: String(epigramId) },
+    });
+  }, []);
+
   const renderItem = useCallback<ListRenderItem<Epigram>>(
-    ({ item }) => <EpigramCard epigram={item} />,
-    []
+    ({ item }) => <EpigramCard epigram={item} onPress={handleCardPress} />,
+    [handleCardPress],
   );
 
   function handleEndReached(): void {


### PR DESCRIPTION
Closes #31

## 변경사항

- `app/epigrams/[id].tsx` 동적 라우트 추가 (`useLocalSearchParams`로 id 파싱 + 유효성 검사)
- `src/views/epigram-detail/` 상세 화면 뷰 — 뒤로가기, 본문/작성자/출처(외부 링크)/태그/좋아요
- `src/features/epigram-like/` 좋아요 훅 + 버튼 — 낙관적 업데이트, 실패 시 롤백, 성공 시 서버 응답으로 캐시 갱신
- `EpigramFeed`에 `onPress` 핸들러 연결 → 카드 탭 시 `router.push({ pathname: "/epigrams/[id]", params: { id } })`

## 배경

MOBILE_PLAN.md 구현 우선순위 3번(에피그램 상세). 카드 탭 → 상세 이동 + 좋아요 UX가 end-to-end로 동작하도록 한다.

## 구현 결정

- 좋아요 훅은 웹 `useEpigramLike`를 그대로 포팅하되, URL 프리픽스만 BFF(`/api/epigrams/...`) → 백엔드 직접(`/epigrams/...`)으로 조정
- 상세 카드도 피드 카드와 동일하게 `repeating-linear-gradient` 대안(절대 위치 `View` 반복)으로 줄무늬 배경 유지
- 출처 URL은 `Linking.openURL`로 외부 브라우저 열기
- 뒤로 가기 시 스택 비어 있으면 `/feeds`로 `replace`

## 범위 외 (후속 PR)

- 댓글 섹션
- 수정/삭제/공유 액션 메뉴
- 태그 탭 → 검색 화면 이동

## 테스트 계획

- [ ] 피드에서 카드 탭 → 상세 화면 진입
- [ ] 좋아요 버튼 탭 → 하트·카운트 즉시 반영(낙관적)
- [ ] 네트워크 실패 시 롤백 확인
- [ ] 출처 URL 있는 에피그램에서 링크 탭 → 외부 브라우저 열림
- [ ] 태그 렌더링 정상
- [ ] 뒤로 가기 동작 (스택 진입 / 직접 URL 진입 둘 다)
