### PR TITLE
fix: 에피그램 상세 페이지 인증 가드 추가 (#33)

### DIFF
--- a/src/views/epigram-detail/ui/EpigramDetailScreen.tsx
+++ b/src/views/epigram-detail/ui/EpigramDetailScreen.tsx
@@ -1,4 +1,4 @@
-import { router } from "expo-router";
+import { Redirect, router } from "expo-router";
 import { ArrowLeft, ExternalLink } from "lucide-react-native";
 import { type ReactElement } from "react";
 import {
@@ -12,6 +12,7 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { useEpigramDetail, type EpigramDetail } from "~/entities/epigram";
+import { useMe } from "~/entities/user";
 import { LikeButton } from "~/features/epigram-like";
 
 interface EpigramDetailScreenProps {
@@ -118,15 +119,27 @@ function Reference({
 
 export function EpigramDetailScreen({
   epigramId,
-}: EpigramDetailScreenProps): ReactElement {
-  const { data: epigram, isLoading, isError } = useEpigramDetail(epigramId);
+}: EpigramDetailScreenProps): ReactElement | null {
+  const { user, isLoading: isMeLoading } = useMe();
+  const {
+    data: epigram,
+    isLoading: isEpigramLoading,
+    isError,
+  } = useEpigramDetail(epigramId);
+
+  if (isMeLoading) return null;
+  if (!user) return <Redirect href="/login" />;
 
   return (
     <SafeAreaView className="flex-1 bg-background" edges={["top"]}>
       <View className="flex-row items-center px-screen-x py-2">
         <BackButton />
       </View>
-      <ShowContent epigram={epigram} isLoading={isLoading} isError={isError} />
+      <ShowContent
+        epigram={epigram}
+        isLoading={isEpigramLoading}
+        isError={isError}
+      />
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
Closes #33

## 변경사항

`EpigramDetailScreen`에 인증 가드 추가.

- `useMe`로 로그인 상태 확인
- `isLoading` 동안 `null` 반환 (깜빡임 방지)
- 미인증이면 `<Redirect href="/login" />`

## 배경

웹 `src/middleware.ts`는 `/epigrams/:id`를 인증 필요 경로로 보호하는데, 모바일 포팅 시 해당 가드가 누락되어 있었다. 로그인 없이 접근 시 `useEpigramDetail`이 `isLiked` 필드 때문에 401을 반환한다.

## 패턴 일관성

`LoginScreen`, `SignUpScreen`에서 이미 사용 중인 `useMe` + `Redirect` 패턴과 동일한 형태.

## 범위 외

- `/addepigram`, `/mypage` 등 다른 인증 필수 경로 가드 (별도 이슈로)

## 테스트 계획

- [ ] 비로그인 상태에서 피드 → 카드 탭 시 `/login`으로 이동 확인
- [ ] 로그인 상태에서 상세 정상 렌더링
- [ ] 로그인 후 상세로 복귀 동작 (push 스택 정상)
