### PR TITLE
fix: /addepigram·/mypage 인증 가드 추가 (#35)

### DIFF
--- a/app/(tabs)/addepigram.tsx
+++ b/app/(tabs)/addepigram.tsx
@@ -1,12 +1,25 @@
-import { Text, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { Redirect } from "expo-router";
+import type { ReactElement } from "react";
+import { Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
-export default function AddEpigramScreen() {
+import { useMe } from "~/entities/user";
+
+export default function AddEpigramScreen(): ReactElement | null {
+  const { user, isLoading } = useMe();
+
+  if (isLoading) return null;
+  if (!user) return <Redirect href="/login" />;
+
   return (
     <SafeAreaView className="flex-1 bg-background">
       <View className="flex-1 items-center justify-center px-screen-x">
-        <Text className="font-sans text-2xl font-bold text-black-900">에피그램 작성</Text>
-        <Text className="mt-2 font-sans text-sm text-blue-400">폼은 추후 구현 예정</Text>
+        <Text className="font-sans text-2xl font-bold text-black-900">
+          에피그램 작성
+        </Text>
+        <Text className="mt-2 font-sans text-sm text-blue-400">
+          폼은 추후 구현 예정
+        </Text>
       </View>
     </SafeAreaView>
   );

--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -1,12 +1,25 @@
-import { Text, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { Redirect } from "expo-router";
+import type { ReactElement } from "react";
+import { Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
-export default function MypageScreen() {
+import { useMe } from "~/entities/user";
+
+export default function MypageScreen(): ReactElement | null {
+  const { user, isLoading } = useMe();
+
+  if (isLoading) return null;
+  if (!user) return <Redirect href="/login" />;
+
   return (
     <SafeAreaView className="flex-1 bg-background">
       <View className="flex-1 items-center justify-center px-screen-x">
-        <Text className="font-sans text-2xl font-bold text-black-900">마이페이지</Text>
-        <Text className="mt-2 font-sans text-sm text-blue-400">감정 기록·활동 차트</Text>
+        <Text className="font-sans text-2xl font-bold text-black-900">
+          마이페이지
+        </Text>
+        <Text className="mt-2 font-sans text-sm text-blue-400">
+          감정 기록·활동 차트
+        </Text>
       </View>
     </SafeAreaView>
   );


### PR DESCRIPTION
Closes #35

## 변경사항

`AddEpigramScreen`, `MypageScreen`에 인증 가드 추가. `LoginScreen`·`SignUpScreen`·`EpigramDetailScreen`과 동일 패턴.

- `useMe`로 로그인 상태 확인
- `isLoading` 동안 `null` 반환
- 미인증이면 `<Redirect href="/login" />`

## 배경

웹 `src/middleware.ts`는 `/addepigram`, `/mypage`를 인증 필요 경로로 보호한다. 모바일 포팅 시 가드가 누락되어 있어 동기화.

두 스크린은 아직 플레이스홀더지만, 추후 구현이 `useMe` 등 훅에 의존하므로 가드를 지금 넣어 둔다.

## 테스트 계획

- [ ] 비로그인 상태에서 `작성` 탭 탭 시 `/login`으로 이동
- [ ] 비로그인 상태에서 `마이` 탭 탭 시 `/login`으로 이동
- [ ] 로그인 상태에서 두 탭 정상 렌더링
