### PR TITLE
fix: 에피그램 상세 기본 헤더 숨김 (#37)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -46,6 +46,7 @@ export default function RootLayout() {
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
           <Stack.Screen name="login" options={{ headerShown: false }} />
           <Stack.Screen name="signup" options={{ headerShown: false }} />
+          <Stack.Screen name="epigrams/[id]" options={{ headerShown: false }} />
           <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
         </Stack>
         <StatusBar style="auto" />


### PR DESCRIPTION
Closes #37

## 변경사항

루트 `app/_layout.tsx` Stack에 `<Stack.Screen name="epigrams/[id]" options={{ headerShown: false }} />` 추가.

## 배경

Expo Router는 `app/` 하위 파일을 파일 기반으로 자동 라우팅하므로 `<Stack.Screen>` 등록 없이도 라우팅은 동작한다. 다만 옵션이 지정되지 않으면 Expo Router 기본 헤더(제목·뒤로 버튼)가 자동 노출되는데, `EpigramDetailScreen`은 이미 자체 `BackButton`을 렌더하므로 헤더가 중복된다.

## 테스트 계획

- [ ] 상세 페이지 진입 시 상단 기본 헤더가 사라지고 자체 BackButton만 남음
