### PR TITLE
feat: 로그인 페이지 게스트 로그인 버튼 추가 (#39)

### DIFF
--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -3,5 +3,6 @@ export type { LoginFormValues } from "./model/loginSchema";
 export { signUpSchema } from "./model/signUpSchema";
 export type { SignUpFormValues } from "./model/signUpSchema";
 
+export { GuestLoginButton } from "./ui/GuestLoginButton";
 export { LoginForm } from "./ui/LoginForm";
 export { SignUpForm } from "./ui/SignUpForm";

--- a/src/features/auth/ui/GuestLoginButton.tsx
+++ b/src/features/auth/ui/GuestLoginButton.tsx
@@ -1,0 +1,59 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { router } from "expo-router";
+import { useState, type ReactElement } from "react";
+import { ActivityIndicator, Pressable, Text, View } from "react-native";
+
+import { signIn } from "~/entities/user";
+import { cn } from "~/shared/lib/cn";
+
+const GUEST_CREDENTIALS = {
+  email: "guest13325@naver.com",
+  password: "@qwer1234",
+} as const;
+
+export function GuestLoginButton(): ReactElement {
+  const queryClient = useQueryClient();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleGuestLogin(): Promise<void> {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const { user } = await signIn(GUEST_CREDENTIALS);
+      queryClient.setQueryData(["me"], user);
+      router.replace("/feeds");
+    } catch {
+      setError("게스트 로그인에 실패했습니다. 잠시 후 다시 시도해주세요.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <View className="gap-1">
+      <Pressable
+        onPress={handleGuestLogin}
+        disabled={isLoading}
+        accessibilityRole="button"
+        accessibilityLabel="게스트로 둘러보기"
+        accessibilityState={{ busy: isLoading, disabled: isLoading }}
+        className={cn(
+          "h-touch-lg items-center justify-center rounded-xl border border-blue-400 bg-surface active:bg-blue-200",
+          isLoading && "opacity-60",
+        )}
+      >
+        {isLoading ? (
+          <ActivityIndicator color="#6a82a9" />
+        ) : (
+          <Text className="font-sans text-base font-semibold text-blue-600">
+            게스트로 둘러보기
+          </Text>
+        )}
+      </Pressable>
+      {error !== null && (
+        <Text className="font-sans text-xs text-error">{error}</Text>
+      )}
+    </View>
+  );
+}

--- a/src/views/login/ui/LoginScreen.tsx
+++ b/src/views/login/ui/LoginScreen.tsx
@@ -4,7 +4,7 @@ import { KeyboardAvoidingView, Platform, Pressable, ScrollView, Text, View } fro
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { useMe } from "~/entities/user";
-import { LoginForm } from "~/features/auth";
+import { GuestLoginButton, LoginForm } from "~/features/auth";
 
 export function LoginScreen(): ReactElement | null {
   const { user, isLoading } = useMe();
@@ -32,6 +32,9 @@ export function LoginScreen(): ReactElement | null {
             <Text className="font-sans text-sm text-black-300">인생 명언을 모아보세요</Text>
           </View>
           <LoginForm />
+          <View className="mt-3">
+            <GuestLoginButton />
+          </View>
           <View className="mt-6 flex-row justify-center gap-1">
             <Text className="font-sans text-sm text-black-300">아직 회원이 아니신가요?</Text>
             <Pressable onPress={handleGoToSignUp} accessibilityRole="link">


### PR DESCRIPTION
Closes #39

## 변경사항

- `src/features/auth/ui/GuestLoginButton.tsx` 신규 추가
- 고정 게스트 계정(`guest13325@naver.com` / `@qwer1234`)으로 `signIn` 호출 → `queryClient.setQueryData(["me"], user)` → `/feeds`로 `router.replace`
- 실패 시 버튼 아래 에러 메시지 인라인 표시
- `LoginScreen`에 `GuestLoginButton`을 `LoginForm` 바로 아래 배치

## 디자인 결정

`Button` 공용 컴포넌트는 단일 variant만 지원(primary: 파란 배경)하므로 guest 버튼은 `Pressable`을 직접 사용. Secondary 스타일(흰 배경 + 파란 테두리/텍스트)로 primary와 시각적으로 구분되도록 구성. ActivityIndicator 색상도 파란 계열로 맞춤.

## 테스트 계획

- [ ] 게스트 버튼 탭 → 로딩 → `/feeds`로 이동
- [ ] 네트워크 차단 상태에서 탭 → 에러 메시지 표시
- [ ] 정식 로그인 폼과의 시각적 대비(primary vs secondary) 확인
