### PR TITLE
feat: 에피그램 상세 댓글 섹션 (목록 + 작성) (#41)

### DIFF
--- a/src/entities/comment/index.ts
+++ b/src/entities/comment/index.ts
@@ -4,3 +4,5 @@ export type { Comment, CommentListResponse, Writer } from "./model/schema";
 export { useEpigramComments } from "./api/useEpigramComments";
 export { useMyComments } from "./api/useMyComments";
 export { useRecentComments } from "./api/useRecentComments";
+
+export { WriterAvatar } from "./ui/WriterAvatar";

--- a/src/entities/comment/ui/WriterAvatar.tsx
+++ b/src/entities/comment/ui/WriterAvatar.tsx
@@ -1,0 +1,31 @@
+import { User } from "lucide-react-native";
+import type { ReactElement } from "react";
+import { Image, View } from "react-native";
+
+import type { Writer } from "../model/schema";
+
+interface WriterAvatarProps {
+  writer: Writer;
+  size?: number;
+}
+
+export function WriterAvatar({ writer, size = 36 }: WriterAvatarProps): ReactElement {
+  if (writer.image) {
+    return (
+      <Image
+        source={{ uri: writer.image }}
+        accessibilityLabel={writer.nickname}
+        style={{ width: size, height: size, borderRadius: size / 2 }}
+      />
+    );
+  }
+
+  return (
+    <View
+      className="items-center justify-center rounded-full bg-blue-200"
+      style={{ width: size, height: size }}
+    >
+      <User size={Math.round(size * 0.45)} color="#2b6cb0" />
+    </View>
+  );
+}

--- a/src/features/comment-create/index.ts
+++ b/src/features/comment-create/index.ts
@@ -1,0 +1,2 @@
+export { CommentForm } from "./ui/CommentForm";
+export { useCommentCreate } from "./model/useCommentCreate";

--- a/src/features/comment-create/model/useCommentCreate.ts
+++ b/src/features/comment-create/model/useCommentCreate.ts
@@ -1,0 +1,71 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+
+import type { Comment } from "~/entities/comment";
+import { apiClient } from "~/shared/api/client";
+
+interface CreateCommentBody {
+  epigramId: number;
+  isPrivate: boolean;
+  content: string;
+}
+
+interface UseCommentCreateReturn {
+  content: string;
+  isPrivate: boolean;
+  isSubmitting: boolean;
+  hasError: boolean;
+  canSubmit: boolean;
+  handleContentChange: (value: string) => void;
+  handlePrivateToggle: () => void;
+  handleSubmit: () => void;
+}
+
+export function useCommentCreate(epigramId: number): UseCommentCreateReturn {
+  const queryClient = useQueryClient();
+  const [content, setContent] = useState("");
+  const [isPrivate, setIsPrivate] = useState(false);
+  const [hasSubmitError, setHasSubmitError] = useState(false);
+
+  const { mutate, isPending: isSubmitting } = useMutation({
+    mutationFn: (body: CreateCommentBody) =>
+      apiClient.post<Comment>("/comments", body).then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["epigrams", epigramId, "comments"] });
+      setContent("");
+      setIsPrivate(false);
+      setHasSubmitError(false);
+    },
+    onError: () => {
+      setHasSubmitError(true);
+    },
+  });
+
+  const canSubmit = content.trim().length > 0;
+
+  function handleContentChange(value: string): void {
+    setContent(value);
+    if (hasSubmitError) setHasSubmitError(false);
+  }
+
+  function handlePrivateToggle(): void {
+    setIsPrivate((prev) => !prev);
+  }
+
+  function handleSubmit(): void {
+    const trimmed = content.trim();
+    if (!trimmed) return;
+    mutate({ epigramId, isPrivate, content: trimmed });
+  }
+
+  return {
+    content,
+    isPrivate,
+    isSubmitting,
+    hasError: hasSubmitError,
+    canSubmit,
+    handleContentChange,
+    handlePrivateToggle,
+    handleSubmit,
+  };
+}

--- a/src/features/comment-create/ui/CommentForm.tsx
+++ b/src/features/comment-create/ui/CommentForm.tsx
@@ -1,0 +1,90 @@
+import { Lock, Unlock, User } from "lucide-react-native";
+import type { ReactElement } from "react";
+import { Image, Pressable, Text, TextInput, View } from "react-native";
+
+import { Button } from "~/shared/ui/Button";
+
+import { useCommentCreate } from "../model/useCommentCreate";
+
+interface CommentFormProps {
+  epigramId: number;
+  userImage?: string | null;
+}
+
+const MAX_LENGTH = 100;
+
+export function CommentForm({ epigramId, userImage }: CommentFormProps): ReactElement {
+  const {
+    content,
+    isPrivate,
+    isSubmitting,
+    hasError,
+    canSubmit,
+    handleContentChange,
+    handlePrivateToggle,
+    handleSubmit,
+  } = useCommentCreate(epigramId);
+
+  return (
+    <View className="flex-row gap-3">
+      <View
+        className="h-9 w-9 items-center justify-center overflow-hidden rounded-full bg-blue-200"
+        accessibilityLabel="내 프로필"
+      >
+        {userImage ? (
+          <Image source={{ uri: userImage }} className="h-full w-full" />
+        ) : (
+          <User size={16} color="#2b6cb0" />
+        )}
+      </View>
+
+      <View className="flex-1 gap-2 rounded-2xl border border-blue-200 bg-white p-3">
+        <TextInput
+          value={content}
+          onChangeText={handleContentChange}
+          placeholder="100자 이내로 입력해주세요."
+          placeholderTextColor="#abb8ce"
+          maxLength={MAX_LENGTH}
+          multiline
+          numberOfLines={2}
+          className="min-h-12 font-sans text-sm text-black-700"
+          textAlignVertical="top"
+        />
+
+        {hasError && (
+          <Text className="font-sans text-xs text-error">
+            댓글 저장에 실패했습니다. 다시 시도해주세요.
+          </Text>
+        )}
+
+        <View className="flex-row items-center justify-between">
+          <Pressable
+            onPress={handlePrivateToggle}
+            accessibilityRole="button"
+            accessibilityLabel={isPrivate ? "비공개 (공개로 전환)" : "공개 (비공개로 전환)"}
+            className="flex-row items-center gap-1 px-1 py-1 active:opacity-60"
+          >
+            {isPrivate ? (
+              <Lock size={12} color="#6a82a9" />
+            ) : (
+              <Unlock size={12} color="#6a82a9" />
+            )}
+            <Text className="font-sans text-xs text-blue-400">
+              {isPrivate ? "비공개" : "공개"}
+            </Text>
+          </Pressable>
+
+          <Button
+            onPress={handleSubmit}
+            isLoading={isSubmitting}
+            disabled={!canSubmit}
+            className="h-9 px-4"
+            textClassName="text-xs"
+          >
+            저장
+          </Button>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/src/shared/lib/date.ts
+++ b/src/shared/lib/date.ts
@@ -1,0 +1,14 @@
+export function formatRelativeTime(dateString: string): string {
+  const now = new Date();
+  const date = new Date(dateString);
+  const diffMs = now.getTime() - date.getTime();
+  const diffMinutes = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffMinutes < 1) return "방금 전";
+  if (diffMinutes < 60) return `${diffMinutes}분 전`;
+  if (diffHours < 24) return `${diffHours}시간 전`;
+  if (diffDays < 7) return `${diffDays}일 전`;
+  return date.toLocaleDateString("ko-KR", { month: "short", day: "numeric" });
+}

--- a/src/views/epigram-detail/ui/EpigramDetailScreen.tsx
+++ b/src/views/epigram-detail/ui/EpigramDetailScreen.tsx
@@ -3,7 +3,9 @@ import { ArrowLeft, ExternalLink } from "lucide-react-native";
 import { type ReactElement } from "react";
 import {
   ActivityIndicator,
+  KeyboardAvoidingView,
   Linking,
+  Platform,
   Pressable,
   StyleSheet,
   Text,
@@ -14,6 +16,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useEpigramDetail, type EpigramDetail } from "~/entities/epigram";
 import { useMe } from "~/entities/user";
 import { LikeButton } from "~/features/epigram-like";
+import { CommentSection } from "~/widgets/comment-section";
 
 interface EpigramDetailScreenProps {
   epigramId: number;
@@ -82,11 +85,7 @@ function ErrorState(): ReactElement {
   );
 }
 
-function Reference({
-  epigram,
-}: {
-  epigram: EpigramDetail;
-}): ReactElement | null {
+function Reference({ epigram }: { epigram: EpigramDetail }): ReactElement | null {
   if (!epigram.referenceTitle) return null;
 
   async function handleOpenReference(): Promise<void> {
@@ -117,6 +116,39 @@ function Reference({
   );
 }
 
+function EpigramCard({ epigram }: { epigram: EpigramDetail }): ReactElement {
+  return (
+    <View className="w-full overflow-hidden rounded-2xl border border-line-100 bg-surface p-6 shadow-card">
+      <RuledLines />
+      <View className="gap-6">
+        <Text className="font-serif text-lg leading-relaxed text-black-700">
+          {epigram.content}
+        </Text>
+        <Text className="text-right font-serif text-base text-blue-400">
+          - {epigram.author} -
+        </Text>
+        <Reference epigram={epigram} />
+        {epigram.tags.length > 0 && (
+          <View className="flex-row flex-wrap justify-end gap-2">
+            {epigram.tags.map((tag) => (
+              <Text key={tag.id} className="font-serif text-sm text-blue-400">
+                #{tag.name}
+              </Text>
+            ))}
+          </View>
+        )}
+        <View className="items-center pt-2">
+          <LikeButton
+            epigramId={epigram.id}
+            likeCount={epigram.likeCount}
+            isLiked={epigram.isLiked}
+          />
+        </View>
+      </View>
+    </View>
+  );
+}
+
 export function EpigramDetailScreen({
   epigramId,
 }: EpigramDetailScreenProps): ReactElement | null {
@@ -135,22 +167,30 @@ export function EpigramDetailScreen({
       <View className="flex-row items-center px-screen-x py-2">
         <BackButton />
       </View>
-      <ShowContent
-        epigram={epigram}
-        isLoading={isEpigramLoading}
-        isError={isError}
-      />
+      <KeyboardAvoidingView
+        className="flex-1"
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
+        <ShowContent
+          epigramId={epigramId}
+          epigram={epigram}
+          isLoading={isEpigramLoading}
+          isError={isError}
+        />
+      </KeyboardAvoidingView>
     </SafeAreaView>
   );
 }
 
 interface ShowContentProps {
+  epigramId: number;
   epigram: EpigramDetail | undefined;
   isLoading: boolean;
   isError: boolean;
 }
 
 function ShowContent({
+  epigramId,
   epigram,
   isLoading,
   isError,
@@ -159,35 +199,9 @@ function ShowContent({
   if (isError || !epigram) return <ErrorState />;
 
   return (
-    <View className="flex-1 px-screen-x py-4">
-      <View className="w-full overflow-hidden rounded-2xl border border-line-100 bg-surface p-6 shadow-card">
-        <RuledLines />
-        <View className="gap-6">
-          <Text className="font-serif text-lg leading-relaxed text-black-700">
-            {epigram.content}
-          </Text>
-          <Text className="text-right font-serif text-base text-blue-400">
-            - {epigram.author} -
-          </Text>
-          <Reference epigram={epigram} />
-          {epigram.tags.length > 0 && (
-            <View className="flex-row flex-wrap justify-end gap-2">
-              {epigram.tags.map((tag) => (
-                <Text key={tag.id} className="font-serif text-sm text-blue-400">
-                  #{tag.name}
-                </Text>
-              ))}
-            </View>
-          )}
-          <View className="items-center pt-2">
-            <LikeButton
-              epigramId={epigram.id}
-              likeCount={epigram.likeCount}
-              isLiked={epigram.isLiked}
-            />
-          </View>
-        </View>
-      </View>
-    </View>
+    <CommentSection
+      epigramId={epigramId}
+      listHeader={<EpigramCard epigram={epigram} />}
+    />
   );
 }

--- a/src/widgets/comment-section/index.ts
+++ b/src/widgets/comment-section/index.ts
@@ -1,0 +1,1 @@
+export { CommentSection } from "./ui/CommentSection";

--- a/src/widgets/comment-section/ui/CommentSection.tsx
+++ b/src/widgets/comment-section/ui/CommentSection.tsx
@@ -1,0 +1,167 @@
+import { MessageCircle } from "lucide-react-native";
+import { memo, type ReactElement } from "react";
+import { ActivityIndicator, FlatList, Text, View } from "react-native";
+
+import { useEpigramComments, WriterAvatar, type Comment } from "~/entities/comment";
+import { useMe } from "~/entities/user";
+import { CommentForm } from "~/features/comment-create";
+import { formatRelativeTime } from "~/shared/lib/date";
+
+const COMMENTS_PAGE_SIZE = 5;
+const SKELETON_COUNT = 3;
+const END_REACHED_THRESHOLD = 0.4;
+
+interface CommentSectionProps {
+  epigramId: number;
+  listHeader?: ReactElement;
+}
+
+function CommentItemBase({ comment }: { comment: Comment }): ReactElement {
+  return (
+    <View className="flex-row gap-3 rounded-xl bg-blue-100 px-4 py-4">
+      <View className="shrink-0">
+        <WriterAvatar writer={comment.writer} />
+      </View>
+      <View className="min-w-0 flex-1">
+        <View className="flex-row items-baseline gap-2">
+          <Text
+            numberOfLines={1}
+            className="font-sans text-sm font-semibold text-black-700"
+          >
+            {comment.writer.nickname}
+          </Text>
+          <Text className="font-sans text-xs text-black-300">
+            {formatRelativeTime(comment.createdAt)}
+          </Text>
+        </View>
+        <Text className="mt-1 font-sans text-sm leading-5 text-black-500">
+          {comment.content}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const CommentItem = memo(CommentItemBase);
+
+function CommentSkeleton(): ReactElement {
+  return (
+    <View className="flex-row gap-3 rounded-xl bg-blue-100 px-4 py-4">
+      <View className="h-9 w-9 rounded-full bg-blue-200" />
+      <View className="flex-1 gap-2">
+        <View className="h-3 w-24 rounded bg-blue-200" />
+        <View className="h-3 w-full rounded bg-blue-200" />
+      </View>
+    </View>
+  );
+}
+
+function EmptyState(): ReactElement {
+  return (
+    <View className="items-center gap-2 rounded-2xl border border-dashed border-line-200 px-4 py-10">
+      <MessageCircle size={28} color="#6a82a9" strokeWidth={1.5} />
+      <Text className="font-sans text-sm font-semibold text-black-700">
+        아직 댓글이 없어요
+      </Text>
+      <Text className="font-sans text-xs text-black-300">
+        첫 번째 댓글을 남겨보세요.
+      </Text>
+    </View>
+  );
+}
+
+function SectionHeader({
+  totalCount,
+  epigramId,
+  userImage,
+}: {
+  totalCount: number | undefined;
+  epigramId: number;
+  userImage: string | null;
+}): ReactElement {
+  return (
+    <View className="gap-4 pt-2">
+      <View className="flex-row items-baseline gap-1">
+        <Text className="font-sans text-lg font-bold text-black-900">댓글</Text>
+        {totalCount !== undefined && (
+          <Text className="font-sans text-lg font-bold text-blue-400">
+            {totalCount}
+          </Text>
+        )}
+      </View>
+      <CommentForm epigramId={epigramId} userImage={userImage} />
+    </View>
+  );
+}
+
+export function CommentSection({
+  epigramId,
+  listHeader,
+}: CommentSectionProps): ReactElement {
+  const { user: me } = useMe();
+  const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
+    useEpigramComments({ epigramId, limit: COMMENTS_PAGE_SIZE });
+
+  const comments = data?.pages.flatMap((page) => page.list) ?? [];
+  const totalCount = data?.pages[0]?.totalCount;
+
+  function handleEndReached(): void {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  }
+
+  function renderListHeader(): ReactElement {
+    return (
+      <View className="gap-6">
+        {listHeader}
+        <SectionHeader
+          totalCount={totalCount}
+          epigramId={epigramId}
+          userImage={me?.image ?? null}
+        />
+      </View>
+    );
+  }
+
+  function renderEmptyComponent(): ReactElement {
+    if (isLoading) {
+      return (
+        <View className="gap-3 pt-4">
+          {Array.from({ length: SKELETON_COUNT }).map((_, index) => (
+            <CommentSkeleton key={index} />
+          ))}
+        </View>
+      );
+    }
+    return (
+      <View className="pt-4">
+        <EmptyState />
+      </View>
+    );
+  }
+
+  function renderListFooter(): ReactElement | null {
+    if (!isFetchingNextPage) return null;
+    return (
+      <View className="py-4">
+        <ActivityIndicator color="#6a82a9" />
+      </View>
+    );
+  }
+
+  return (
+    <FlatList
+      data={comments}
+      keyExtractor={(comment) => String(comment.id)}
+      renderItem={({ item }) => <CommentItem comment={item} />}
+      ListHeaderComponent={renderListHeader}
+      ListEmptyComponent={renderEmptyComponent}
+      ListFooterComponent={renderListFooter}
+      onEndReached={handleEndReached}
+      onEndReachedThreshold={END_REACHED_THRESHOLD}
+      contentContainerClassName="px-screen-x pb-10"
+      ItemSeparatorComponent={() => <View className="h-3" />}
+      ListHeaderComponentStyle={{ marginBottom: 12 }}
+      keyboardShouldPersistTaps="handled"
+    />
+  );
+}


### PR DESCRIPTION
Closes #41

## Summary
- 에피그램 상세 페이지에 댓글 섹션 MVP 추가 (목록 + 작성)
- `FlatList` 기반 무한 스크롤 · `onEndReached`로 다음 페이지 요청
- 공개·비공개 토글 + 100자 제한 댓글 작성 폼, 저장 성공 시 `["epigrams", id, "comments"]` 쿼리 invalidate
- 상세 화면을 `KeyboardAvoidingView` + `FlatList` 구조로 바꿔 카드 + 댓글 목록이 하나의 스크롤러에서 흐르도록 조정
- `WriterAvatar`, `formatRelativeTime` 헬퍼 모바일용으로 포팅

## 주요 파일
- `src/widgets/comment-section/ui/CommentSection.tsx` — 목록 헤더(총 개수 + 작성 폼) · 빈 상태 · 스켈레톤 · 무한 스크롤
- `src/features/comment-create/{model/useCommentCreate.ts,ui/CommentForm.tsx}` — 웹의 `useCommentCreate`·`CommentForm`을 RN으로 포팅
- `src/entities/comment/ui/WriterAvatar.tsx` — 이미지 없으면 `User` 아이콘 플레이스홀더
- `src/shared/lib/date.ts` — `formatRelativeTime`
- `src/views/epigram-detail/ui/EpigramDetailScreen.tsx` — 카드 추출 + FlatList `listHeader`로 전달

## 비범위 (후속 이슈로 분리)
- 댓글 수정/삭제 메뉴
- 작성자 프로필 모달(`UserProfileModal`)

## Test plan
- [ ] 상세 페이지 진입 시 카드 + 댓글 영역이 하나의 스크롤러에서 매끄럽게 흐른다
- [ ] 댓글 미작성 상태: "아직 댓글이 없어요" 빈 상태가 표시된다
- [ ] 초기 로딩 시 스켈레톤 3개가 보인다
- [ ] 공개/비공개 토글 후 작성 → 목록 최상단에서 새 댓글이 보인다 (invalidate 후 재조회)
- [ ] 스크롤 하단 도달 시 다음 페이지가 자동 로드되며 푸터 스피너가 표시된다
- [ ] 작성 실패 시 "댓글 저장에 실패했습니다" 에러 메시지가 인라인으로 표시된다
- [ ] 키보드 올라올 때 입력 영역이 가려지지 않는다 (iOS `padding`)