### PR TITLE
feat: 댓글 수정·삭제 액션 메뉴 (#43)

### DIFF
--- a/src/features/comment-delete/index.ts
+++ b/src/features/comment-delete/index.ts
@@ -1,0 +1,1 @@
+export { useCommentDelete } from "./model/useCommentDelete";

--- a/src/features/comment-delete/model/useCommentDelete.ts
+++ b/src/features/comment-delete/model/useCommentDelete.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Alert } from "react-native";
+
+import { apiClient } from "~/shared/api/client";
+
+interface UseCommentDeleteReturn {
+  handleDeleteClick: () => void;
+  isDeleting: boolean;
+}
+
+export function useCommentDelete(
+  commentId: number,
+  epigramId: number,
+  userId?: number,
+): UseCommentDeleteReturn {
+  const queryClient = useQueryClient();
+
+  const { mutate, isPending: isDeleting } = useMutation({
+    mutationFn: () => apiClient.delete(`/comments/${commentId}`).then((res) => res.data),
+    onSuccess: async () => {
+      const invalidations = [
+        queryClient.invalidateQueries({ queryKey: ["epigrams", epigramId, "comments"] }),
+      ];
+      if (userId !== undefined) {
+        invalidations.push(
+          queryClient.invalidateQueries({ queryKey: ["users", userId, "comments"] }),
+        );
+      }
+      await Promise.all(invalidations);
+    },
+    onError: () => {
+      Alert.alert("삭제 실패", "댓글을 삭제하지 못했습니다. 잠시 후 다시 시도해주세요.");
+    },
+  });
+
+  function handleDeleteClick(): void {
+    Alert.alert(
+      "댓글을 삭제할까요?",
+      undefined,
+      [
+        { text: "취소", style: "cancel" },
+        { text: "삭제", style: "destructive", onPress: () => mutate() },
+      ],
+      { cancelable: true },
+    );
+  }
+
+  return { handleDeleteClick, isDeleting };
+}

--- a/src/features/comment-edit/index.ts
+++ b/src/features/comment-edit/index.ts
@@ -1,0 +1,2 @@
+export { CommentEditForm } from "./ui/CommentEditForm";
+export { useCommentEdit } from "./model/useCommentEdit";

--- a/src/features/comment-edit/model/useCommentEdit.ts
+++ b/src/features/comment-edit/model/useCommentEdit.ts
@@ -1,0 +1,85 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+
+import type { Comment } from "~/entities/comment";
+import { apiClient } from "~/shared/api/client";
+
+interface UpdateCommentBody {
+  isPrivate?: boolean;
+  content?: string;
+}
+
+interface UseCommentEditParams {
+  commentId: number;
+  epigramId: number;
+  initialContent: string;
+  initialIsPrivate: boolean;
+  onCancel: () => void;
+}
+
+interface UseCommentEditReturn {
+  content: string;
+  isPrivate: boolean;
+  isSubmitting: boolean;
+  hasError: boolean;
+  canSubmit: boolean;
+  setContent: (value: string) => void;
+  handlePrivateToggle: () => void;
+  handleSubmit: () => void;
+  handleCancel: () => void;
+}
+
+export function useCommentEdit({
+  commentId,
+  epigramId,
+  initialContent,
+  initialIsPrivate,
+  onCancel,
+}: UseCommentEditParams): UseCommentEditReturn {
+  const queryClient = useQueryClient();
+  const [content, setContent] = useState(initialContent);
+  const [isPrivate, setIsPrivate] = useState(initialIsPrivate);
+
+  const {
+    mutate,
+    isPending: isSubmitting,
+    isError: hasError,
+  } = useMutation({
+    mutationFn: (body: UpdateCommentBody) =>
+      apiClient.patch<Comment>(`/comments/${commentId}`, body).then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["epigrams", epigramId, "comments"] });
+      onCancel();
+    },
+  });
+
+  const canSubmit = content.trim().length > 0;
+
+  function handlePrivateToggle(): void {
+    setIsPrivate((prev) => !prev);
+  }
+
+  function handleSubmit(): void {
+    const trimmed = content.trim();
+    if (!trimmed) return;
+    mutate({ content: trimmed, isPrivate });
+  }
+
+  function handleCancel(): void {
+    setContent(initialContent);
+    setIsPrivate(initialIsPrivate);
+    onCancel();
+  }
+
+  return {
+    content,
+    isPrivate,
+    isSubmitting,
+    hasError,
+    canSubmit,
+    setContent,
+    handlePrivateToggle,
+    handleSubmit,
+    handleCancel,
+  };
+}

--- a/src/features/comment-edit/ui/CommentEditForm.tsx
+++ b/src/features/comment-edit/ui/CommentEditForm.tsx
@@ -1,0 +1,96 @@
+import { Lock, Unlock } from "lucide-react-native";
+import type { ReactElement } from "react";
+import { Pressable, Text, TextInput, View } from "react-native";
+
+import { Button } from "~/shared/ui/Button";
+
+import { useCommentEdit } from "../model/useCommentEdit";
+
+interface CommentEditFormProps {
+  commentId: number;
+  epigramId: number;
+  initialContent: string;
+  initialIsPrivate: boolean;
+  onCancel: () => void;
+}
+
+const MAX_LENGTH = 100;
+
+export function CommentEditForm({
+  commentId,
+  epigramId,
+  initialContent,
+  initialIsPrivate,
+  onCancel,
+}: CommentEditFormProps): ReactElement {
+  const {
+    content,
+    isPrivate,
+    isSubmitting,
+    hasError,
+    canSubmit,
+    setContent,
+    handlePrivateToggle,
+    handleSubmit,
+    handleCancel,
+  } = useCommentEdit({ commentId, epigramId, initialContent, initialIsPrivate, onCancel });
+
+  return (
+    <View className="gap-2 rounded-2xl border border-blue-400 bg-white p-3">
+      <TextInput
+        value={content}
+        onChangeText={setContent}
+        maxLength={MAX_LENGTH}
+        multiline
+        numberOfLines={2}
+        autoFocus
+        placeholderTextColor="#abb8ce"
+        className="min-h-12 font-sans text-sm text-black-700"
+        textAlignVertical="top"
+      />
+
+      {hasError && (
+        <Text className="font-sans text-xs text-error">
+          수정에 실패했습니다. 다시 시도해주세요.
+        </Text>
+      )}
+
+      <View className="flex-row items-center justify-between">
+        <Pressable
+          onPress={handlePrivateToggle}
+          accessibilityRole="button"
+          accessibilityLabel={isPrivate ? "비공개 (공개로 전환)" : "공개 (비공개로 전환)"}
+          className="flex-row items-center gap-1 px-1 py-1 active:opacity-60"
+        >
+          {isPrivate ? (
+            <Lock size={12} color="#6a82a9" />
+          ) : (
+            <Unlock size={12} color="#6a82a9" />
+          )}
+          <Text className="font-sans text-xs text-blue-400">
+            {isPrivate ? "비공개" : "공개"}
+          </Text>
+        </Pressable>
+
+        <View className="flex-row gap-2">
+          <Button
+            onPress={handleCancel}
+            className="h-9 border border-blue-400 bg-white px-4 active:bg-blue-100"
+            textClassName="text-xs text-blue-600"
+          >
+            취소
+          </Button>
+          <Button
+            onPress={handleSubmit}
+            isLoading={isSubmitting}
+            disabled={!canSubmit}
+            className="h-9 px-4"
+            textClassName="text-xs"
+          >
+            저장
+          </Button>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/src/widgets/comment-section/ui/CommentSection.tsx
+++ b/src/widgets/comment-section/ui/CommentSection.tsx
@@ -1,10 +1,12 @@
-import { MessageCircle } from "lucide-react-native";
-import { memo, type ReactElement } from "react";
-import { ActivityIndicator, FlatList, Text, View } from "react-native";
+import { MessageCircle, MoreVertical } from "lucide-react-native";
+import { memo, useState, type ReactElement } from "react";
+import { ActivityIndicator, Alert, FlatList, Pressable, Text, View } from "react-native";
 
 import { useEpigramComments, WriterAvatar, type Comment } from "~/entities/comment";
 import { useMe } from "~/entities/user";
 import { CommentForm } from "~/features/comment-create";
+import { useCommentDelete } from "~/features/comment-delete";
+import { CommentEditForm } from "~/features/comment-edit";
 import { formatRelativeTime } from "~/shared/lib/date";
 
 const COMMENTS_PAGE_SIZE = 5;
@@ -16,23 +18,76 @@ interface CommentSectionProps {
   listHeader?: ReactElement;
 }
 
-function CommentItemBase({ comment }: { comment: Comment }): ReactElement {
+interface CommentItemProps {
+  comment: Comment;
+  epigramId: number;
+  currentUserId: number | undefined;
+}
+
+function CommentItemBase({
+  comment,
+  epigramId,
+  currentUserId,
+}: CommentItemProps): ReactElement {
+  const [isEditing, setIsEditing] = useState(false);
+  const { handleDeleteClick } = useCommentDelete(comment.id, epigramId, currentUserId);
+  const isOwnComment = currentUserId !== undefined && comment.writer.id === currentUserId;
+
+  function handleOpenMenu(): void {
+    Alert.alert(
+      "댓글",
+      undefined,
+      [
+        { text: "수정", onPress: () => setIsEditing(true) },
+        { text: "삭제", style: "destructive", onPress: handleDeleteClick },
+        { text: "취소", style: "cancel" },
+      ],
+      { cancelable: true },
+    );
+  }
+
+  if (isEditing) {
+    return (
+      <CommentEditForm
+        commentId={comment.id}
+        epigramId={epigramId}
+        initialContent={comment.content}
+        initialIsPrivate={comment.isPrivate}
+        onCancel={() => setIsEditing(false)}
+      />
+    );
+  }
+
   return (
     <View className="flex-row gap-3 rounded-xl bg-blue-100 px-4 py-4">
       <View className="shrink-0">
         <WriterAvatar writer={comment.writer} />
       </View>
       <View className="min-w-0 flex-1">
-        <View className="flex-row items-baseline gap-2">
-          <Text
-            numberOfLines={1}
-            className="font-sans text-sm font-semibold text-black-700"
-          >
-            {comment.writer.nickname}
-          </Text>
-          <Text className="font-sans text-xs text-black-300">
-            {formatRelativeTime(comment.createdAt)}
-          </Text>
+        <View className="flex-row items-start justify-between gap-2">
+          <View className="min-w-0 flex-1 flex-row items-baseline gap-2">
+            <Text
+              numberOfLines={1}
+              className="font-sans text-sm font-semibold text-black-700"
+            >
+              {comment.writer.nickname}
+            </Text>
+            <Text className="font-sans text-xs text-black-300">
+              {formatRelativeTime(comment.createdAt)}
+            </Text>
+          </View>
+
+          {isOwnComment && (
+            <Pressable
+              onPress={handleOpenMenu}
+              accessibilityRole="button"
+              accessibilityLabel="댓글 옵션"
+              hitSlop={8}
+              className="shrink-0 rounded-full p-1 active:bg-blue-200"
+            >
+              <MoreVertical size={16} color="#6a82a9" />
+            </Pressable>
+          )}
         </View>
         <Text className="mt-1 font-sans text-sm leading-5 text-black-500">
           {comment.content}
@@ -152,7 +207,9 @@ export function CommentSection({
     <FlatList
       data={comments}
       keyExtractor={(comment) => String(comment.id)}
-      renderItem={({ item }) => <CommentItem comment={item} />}
+      renderItem={({ item }) => (
+        <CommentItem comment={item} epigramId={epigramId} currentUserId={me?.id} />
+      )}
       ListHeaderComponent={renderListHeader}
       ListEmptyComponent={renderEmptyComponent}
       ListFooterComponent={renderListFooter}


### PR DESCRIPTION
Closes #43

## Summary
- 작성자 본인 댓글에만 `MoreVertical` 버튼 노출 → `Alert.alert` 네이티브 액션 시트로 수정/삭제 선택
- 수정 선택 시 댓글을 `CommentEditForm` 으로 inline 교체 (공개·비공개 토글, 100자 제한, 저장 실패 인라인 에러)
- 삭제 선택 시 "댓글을 삭제할까요?" 확인 알럿 → `DELETE /comments/{id}`
- 수정·삭제 성공 시 `["epigrams", id, "comments"]` 및 `["users", userId, "comments"]` 쿼리 invalidate
- 로직은 웹의 `useCommentEdit`·`useCommentDelete` 그대로 재사용, URL prefix만 BFF → 직접 백엔드로 조정

## 주요 파일
- `src/features/comment-edit/{model/useCommentEdit.ts,ui/CommentEditForm.tsx}`
- `src/features/comment-delete/model/useCommentDelete.ts` — 웹 `ConfirmModal` 대신 RN `Alert.alert`
- `src/widgets/comment-section/ui/CommentSection.tsx` — `CommentItem`에 옵션 메뉴 + 편집 상태 전환 추가

## Test plan
- [ ] 자기 댓글에 `⋮` 버튼이 보이고, 타인 댓글엔 보이지 않는다
- [ ] `⋮` → "수정" 선택 시 해당 댓글이 편집 폼으로 바뀐다
- [ ] 저장 누르면 내용이 업데이트되고 목록이 새로 고쳐진다
- [ ] 취소 누르면 편집 전 상태로 되돌아간다
- [ ] `⋮` → "삭제" → "삭제" 확인 시 댓글이 사라지고 총 개수가 줄어든다
- [ ] 네트워크 실패 시 "삭제 실패" 알럿이 표시된다