### PR TITLE
chore: GitHub Actions CI 추가 (#45)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,17 @@ jobs:
           npm config get registry
 
       - name: Install dependencies
-        run: npm ci --verbose
+        id: install
+        run: npm ci --verbose > /tmp/npm-install.log 2>&1
+
+      - name: Show install log on failure
+        if: failure() && steps.install.outcome == 'failure'
+        run: |
+          echo '## npm ci log (last 300 lines)' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          tail -300 /tmp/npm-install.log >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          tail -300 /tmp/npm-install.log
 
       - name: Type check
         run: npm run typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
 
       - name: Build (web bundle)
         id: build
+        env:
+          EXPO_PUBLIC_API_BASE: https://ci.example.com
+          EXPO_PUBLIC_TEAM_ID: ci
         run: npx expo export --platform web > /tmp/build.log 2>&1
 
       - name: Post build log as PR comment on failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    name: Type · Lint
+    name: Type · Lint · Build
     runs-on: ubuntu-latest
 
     steps:
@@ -45,3 +45,6 @@ jobs:
 
       - name: Lint
         run: npm run lint
+
+      - name: Build (web bundle)
+        run: npx expo export --platform web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,6 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   ci:
     name: Type · Lint · Build
@@ -25,30 +21,8 @@ jobs:
           node-version: 22
           cache: npm
 
-      - name: Debug versions
-        run: |
-          node --version
-          npm --version
-          npm config get registry
-
       - name: Install dependencies
-        id: install
-        run: npm ci --verbose > /tmp/npm-install.log 2>&1
-
-      - name: Post install log as PR comment on failure
-        if: failure() && steps.install.outcome == 'failure' && github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          {
-            echo '## CI debug: npm ci failure log (last 200 lines)'
-            echo ''
-            echo '```'
-            tail -200 /tmp/npm-install.log
-            echo '```'
-          } > /tmp/comment.md
-          gh pr comment "$PR_NUMBER" --body-file /tmp/comment.md --repo "$GITHUB_REPOSITORY"
+        run: npm ci
 
       - name: Type check
         run: npm run typecheck
@@ -57,23 +31,7 @@ jobs:
         run: npm run lint
 
       - name: Build (web bundle)
-        id: build
         env:
           EXPO_PUBLIC_API_BASE: https://ci.example.com
           EXPO_PUBLIC_TEAM_ID: ci
-        run: npx expo export --platform web > /tmp/build.log 2>&1
-
-      - name: Post build log as PR comment on failure
-        if: failure() && steps.build.outcome == 'failure' && github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          {
-            echo '## CI debug: expo export web failure log (last 200 lines)'
-            echo ''
-            echo '```'
-            tail -200 /tmp/build.log
-            echo '```'
-          } > /tmp/build-comment.md
-          gh pr comment "$PR_NUMBER" --body-file /tmp/build-comment.md --repo "$GITHUB_REPOSITORY"
+        run: npx expo export --platform web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,14 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Debug versions
+        run: |
+          node --version
+          npm --version
+          npm config get registry
+
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --verbose
 
       - name: Type check
         run: npm run typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,14 +31,20 @@ jobs:
         id: install
         run: npm ci --verbose > /tmp/npm-install.log 2>&1
 
-      - name: Show install log on failure
-        if: failure() && steps.install.outcome == 'failure'
+      - name: Post install log as PR comment on failure
+        if: failure() && steps.install.outcome == 'failure' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          echo '## npm ci log (last 300 lines)' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          tail -300 /tmp/npm-install.log >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          tail -300 /tmp/npm-install.log
+          {
+            echo '## CI debug: npm ci failure log (last 200 lines)'
+            echo ''
+            echo '```'
+            tail -200 /tmp/npm-install.log
+            echo '```'
+          } > /tmp/comment.md
+          gh pr comment "$PR_NUMBER" --body-file /tmp/comment.md --repo "$GITHUB_REPOSITORY"
 
       - name: Type check
         run: npm run typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  ci:
+    name: Type · Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,4 +57,20 @@ jobs:
         run: npm run lint
 
       - name: Build (web bundle)
-        run: npx expo export --platform web
+        id: build
+        run: npx expo export --platform web > /tmp/build.log 2>&1
+
+      - name: Post build log as PR comment on failure
+        if: failure() && steps.build.outcome == 'failure' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          {
+            echo '## CI debug: expo export web failure log (last 200 lines)'
+            echo ''
+            echo '```'
+            tail -200 /tmp/build.log
+            echo '```'
+          } > /tmp/build-comment.md
+          gh pr comment "$PR_NUMBER" --body-file /tmp/build-comment.md --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   ci:
     name: Type · Lint · Build

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "@types/react": "~19.1.0",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~10.0.0",
+        "prettier": "^3.8.3",
         "prettier-plugin-tailwindcss": "^0.5.14",
         "tailwindcss": "^3.4.19",
         "typescript": "~5.9.2"
@@ -11004,6 +11005,22 @@
       "resolved": "https://registry.npmjs.org/pretendard/-/pretendard-1.3.9.tgz",
       "integrity": "sha512-PaQAADyLY5v4kYFwkpSJHbSSYIkiriY/1xXw75TKoZ9UQQqeU+tvP05yTdZAWibiIYoo8ZKtRv8PM7w0IaywSw==",
       "license": "OFL-1.1"
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/prettier-plugin-tailwindcss": {
       "version": "0.5.14",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@expo-google-fonts/nanum-myeongjo": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/react": "~19.1.0",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~10.0.0",
+    "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.5.14",
     "tailwindcss": "^3.4.19",
     "typescript": "~5.9.2"


### PR DESCRIPTION
Closes #45

## Summary
- `.github/workflows/ci.yml` 추가 — `pull_request` (main) · `push` (main) 트리거
- 단계: `npm ci` → `npm run typecheck` → `npm run lint`
- Node 22 LTS + npm 캐시
- `package.json` 에 `typecheck` 스크립트 추가 (`tsc --noEmit`)

## 비범위
- Expo 네이티브 빌드 (EAS)
- E2E (Detox/Maestro)
- Format check (prettier 미설정)

## Test plan
- [ ] 본 PR 의 Checks 탭에서 CI 가 통과한다
- [ ] 이후 모든 PR에서 CI status 가 자동 표시된다