### PR TITLE
refactor: EpigramDetailCard 위젯 분리 (#51)

### DIFF
--- a/src/views/epigram-detail/ui/EpigramDetailScreen.tsx
+++ b/src/views/epigram-detail/ui/EpigramDetailScreen.tsx
@@ -1,49 +1,23 @@
 import { Redirect, router } from "expo-router";
-import { ArrowLeft, ExternalLink } from "lucide-react-native";
+import { ArrowLeft } from "lucide-react-native";
 import { type ReactElement } from "react";
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
-  Linking,
   Platform,
   Pressable,
-  StyleSheet,
   Text,
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-import { useEpigramDetail, type EpigramDetail } from "~/entities/epigram";
+import { useEpigramDetail } from "~/entities/epigram";
 import { useMe } from "~/entities/user";
-import { LikeButton } from "~/features/epigram-like";
+import { EpigramDetailCard } from "~/widgets/epigram-detail-card";
 import { EpigramDetailList } from "~/widgets/epigram-detail-list";
 
 interface EpigramDetailScreenProps {
   epigramId: number;
-}
-
-const RULE_LINE_SPACING = 28;
-const RULE_LINE_COUNT = 24;
-const RULE_LINE_COLOR = "#f2f2f2";
-
-function RuledLines(): ReactElement {
-  return (
-    <View pointerEvents="none" style={StyleSheet.absoluteFill}>
-      {Array.from({ length: RULE_LINE_COUNT }).map((_, index) => (
-        <View
-          key={index}
-          style={{
-            position: "absolute",
-            left: 0,
-            right: 0,
-            top: (index + 1) * RULE_LINE_SPACING,
-            height: 1,
-            backgroundColor: RULE_LINE_COLOR,
-          }}
-        />
-      ))}
-    </View>
-  );
 }
 
 function BackButton(): ReactElement {
@@ -85,74 +59,6 @@ function ErrorState(): ReactElement {
   );
 }
 
-function Reference({
-  epigram,
-}: {
-  epigram: EpigramDetail;
-}): ReactElement | null {
-  if (!epigram.referenceTitle) return null;
-
-  async function handleOpenReference(): Promise<void> {
-    if (!epigram.referenceUrl) return;
-    await Linking.openURL(epigram.referenceUrl);
-  }
-
-  if (!epigram.referenceUrl) {
-    return (
-      <Text className="text-right font-sans text-xs text-black-300">
-        {epigram.referenceTitle}
-      </Text>
-    );
-  }
-
-  return (
-    <Pressable
-      onPress={handleOpenReference}
-      accessibilityRole="link"
-      accessibilityLabel={`출처 ${epigram.referenceTitle} 열기`}
-      className="flex-row items-center justify-end gap-1 self-end"
-    >
-      <Text className="font-sans text-xs text-blue-500 underline">
-        {epigram.referenceTitle}
-      </Text>
-      <ExternalLink size={12} color="#3b82f6" />
-    </Pressable>
-  );
-}
-
-function EpigramCard({ epigram }: { epigram: EpigramDetail }): ReactElement {
-  return (
-    <View className="w-full overflow-hidden rounded-2xl border border-line-100 bg-surface p-6 shadow-card">
-      <RuledLines />
-      <View className="gap-6">
-        <Text className="font-serif text-lg leading-relaxed text-black-700">
-          {epigram.content}
-        </Text>
-        <Text className="text-right font-serif text-base text-blue-400">
-          - {epigram.author} -
-        </Text>
-        <Reference epigram={epigram} />
-        {epigram.tags.length > 0 && (
-          <View className="flex-row flex-wrap justify-end gap-2">
-            {epigram.tags.map((tag) => (
-              <Text key={tag.id} className="font-serif text-sm text-blue-400">
-                #{tag.name}
-              </Text>
-            ))}
-          </View>
-        )}
-        <View className="items-center pt-2">
-          <LikeButton
-            epigramId={epigram.id}
-            likeCount={epigram.likeCount}
-            isLiked={epigram.isLiked}
-          />
-        </View>
-      </View>
-    </View>
-  );
-}
-
 export function EpigramDetailScreen({
   epigramId,
 }: EpigramDetailScreenProps): ReactElement | null {
@@ -172,7 +78,7 @@ export function EpigramDetailScreen({
     return (
       <EpigramDetailList
         epigramId={epigramId}
-        listHeader={<EpigramCard epigram={epigram} />}
+        listHeader={<EpigramDetailCard epigram={epigram} />}
       />
     );
   }

--- a/src/widgets/epigram-detail-card/index.ts
+++ b/src/widgets/epigram-detail-card/index.ts
@@ -1,0 +1,1 @@
+export { EpigramDetailCard } from "./ui/EpigramDetailCard";

--- a/src/widgets/epigram-detail-card/ui/EpigramDetailCard.tsx
+++ b/src/widgets/epigram-detail-card/ui/EpigramDetailCard.tsx
@@ -1,0 +1,104 @@
+import { ExternalLink } from "lucide-react-native";
+import type { ReactElement } from "react";
+import { Linking, Pressable, StyleSheet, Text, View } from "react-native";
+
+import type { EpigramDetail } from "~/entities/epigram";
+import { LikeButton } from "~/features/epigram-like";
+
+interface EpigramDetailCardProps {
+  epigram: EpigramDetail;
+}
+
+const RULE_LINE_SPACING = 28;
+const RULE_LINE_COUNT = 24;
+const RULE_LINE_COLOR = "#f2f2f2";
+
+function RuledLines(): ReactElement {
+  return (
+    <View pointerEvents="none" style={StyleSheet.absoluteFill}>
+      {Array.from({ length: RULE_LINE_COUNT }).map((_, index) => (
+        <View
+          key={index}
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            top: (index + 1) * RULE_LINE_SPACING,
+            height: 1,
+            backgroundColor: RULE_LINE_COLOR,
+          }}
+        />
+      ))}
+    </View>
+  );
+}
+
+function Reference({
+  epigram,
+}: {
+  epigram: EpigramDetail;
+}): ReactElement | null {
+  if (!epigram.referenceTitle) return null;
+
+  async function handleOpenReference(): Promise<void> {
+    if (!epigram.referenceUrl) return;
+    await Linking.openURL(epigram.referenceUrl);
+  }
+
+  if (!epigram.referenceUrl) {
+    return (
+      <Text className="text-right font-sans text-xs text-black-300">
+        {epigram.referenceTitle}
+      </Text>
+    );
+  }
+
+  return (
+    <Pressable
+      onPress={handleOpenReference}
+      accessibilityRole="link"
+      accessibilityLabel={`출처 ${epigram.referenceTitle} 열기`}
+      className="flex-row items-center justify-end gap-1 self-end"
+    >
+      <Text className="font-sans text-xs text-blue-500 underline">
+        {epigram.referenceTitle}
+      </Text>
+      <ExternalLink size={12} color="#3b82f6" />
+    </Pressable>
+  );
+}
+
+export function EpigramDetailCard({
+  epigram,
+}: EpigramDetailCardProps): ReactElement {
+  return (
+    <View className="w-full overflow-hidden rounded-2xl border border-line-100 bg-surface p-6 shadow-card">
+      <RuledLines />
+      <View className="gap-6">
+        <Text className="font-serif text-lg leading-relaxed text-black-700">
+          {epigram.content}
+        </Text>
+        <Text className="text-right font-serif text-base text-blue-400">
+          - {epigram.author} -
+        </Text>
+        <Reference epigram={epigram} />
+        {epigram.tags.length > 0 && (
+          <View className="flex-row flex-wrap justify-end gap-2">
+            {epigram.tags.map((tag) => (
+              <Text key={tag.id} className="font-serif text-sm text-blue-400">
+                #{tag.name}
+              </Text>
+            ))}
+          </View>
+        )}
+        <View className="items-center pt-2">
+          <LikeButton
+            epigramId={epigram.id}
+            likeCount={epigram.likeCount}
+            isLiked={epigram.isLiked}
+          />
+        </View>
+      </View>
+    </View>
+  );
+}


### PR DESCRIPTION
Closes #51

## Summary
`EpigramDetailScreen`에 인라인 정의돼 있던 상세용 `EpigramCard`(+ `RuledLines`, `Reference`, 룰 라인 상수)를 `widgets/epigram-detail-card/EpigramDetailCard`로 분리. 피드용 `widgets/epigram-card/EpigramCard`와의 이름 충돌도 해소.

## 변경
- 신규: `widgets/epigram-detail-card/ui/EpigramDetailCard.tsx`
- `EpigramDetailScreen`은 페이지 chrome(`BackButton`·`LoadingState`·`ErrorState`)와 데이터 분기만 남김
- `Linking`/`ExternalLink` import도 위젯 쪽으로 이동

## 비범위
- 피드용 `EpigramCard`, 댓글 mutation entity 분리, query key factory — 별도 이슈

## Test plan
- [ ] CI typecheck/lint/build 통과
- [ ] 상세 화면 렌더 확인 (룰 라인·출처·태그·좋아요)
- [ ] 출처 링크 탭 시 외부 브라우저 열림

🤖 Generated with [Claude Code](https://claude.com/claude-code)