### PR TITLE
refactor: React Query key factory 도입 (#53)

### DIFF
--- a/src/entities/comment/api/keys.ts
+++ b/src/entities/comment/api/keys.ts
@@ -1,0 +1,15 @@
+interface ListParams {
+  limit: number;
+}
+
+export const commentKeys = {
+  all: ["comments"] as const,
+  recent: (params: ListParams) => ["comments", params] as const,
+  byEpigram: (epigramId: number) =>
+    ["epigrams", epigramId, "comments"] as const,
+  byEpigramList: (epigramId: number, params: ListParams) =>
+    ["epigrams", epigramId, "comments", params] as const,
+  byUser: (userId: number) => ["users", userId, "comments"] as const,
+  byUserList: (userId: number, params: ListParams) =>
+    ["users", userId, "comments", params] as const,
+};

--- a/src/entities/comment/api/useEpigramComments.ts
+++ b/src/entities/comment/api/useEpigramComments.ts
@@ -6,7 +6,11 @@ import {
 
 import { apiClient } from "~/shared/api/client";
 
-import { commentListResponseSchema, type CommentListResponse } from "../model/schema";
+import {
+  commentListResponseSchema,
+  type CommentListResponse,
+} from "../model/schema";
+import { commentKeys } from "./keys";
 
 interface UseEpigramCommentsParams {
   epigramId: number;
@@ -21,13 +25,15 @@ export function useEpigramComments({
   Error
 > {
   return useInfiniteQuery({
-    queryKey: ["epigrams", epigramId, "comments", { limit }],
+    queryKey: commentKeys.byEpigramList(epigramId, { limit }),
     enabled: epigramId > 0,
     queryFn: async ({ pageParam }) => {
       const params = new URLSearchParams({ limit: String(limit) });
       if (pageParam !== undefined) params.set("cursor", String(pageParam));
 
-      const response = await apiClient.get<unknown>(`/epigrams/${epigramId}/comments?${params}`);
+      const response = await apiClient.get<unknown>(
+        `/epigrams/${epigramId}/comments?${params}`,
+      );
       return commentListResponseSchema.parse(response.data);
     },
     initialPageParam: undefined as number | undefined,

--- a/src/entities/comment/api/useMyComments.ts
+++ b/src/entities/comment/api/useMyComments.ts
@@ -6,7 +6,11 @@ import {
 
 import { apiClient } from "~/shared/api/client";
 
-import { commentListResponseSchema, type CommentListResponse } from "../model/schema";
+import {
+  commentListResponseSchema,
+  type CommentListResponse,
+} from "../model/schema";
+import { commentKeys } from "./keys";
 
 interface UseMyCommentsParams {
   userId: number;
@@ -21,13 +25,15 @@ export function useMyComments({
   Error
 > {
   return useInfiniteQuery({
-    queryKey: ["users", userId, "comments", { limit }],
+    queryKey: commentKeys.byUserList(userId, { limit }),
     enabled: userId > 0,
     queryFn: async ({ pageParam }) => {
       const params = new URLSearchParams({ limit: String(limit) });
       if (pageParam !== undefined) params.set("cursor", String(pageParam));
 
-      const response = await apiClient.get<unknown>(`/users/${userId}/comments?${params}`);
+      const response = await apiClient.get<unknown>(
+        `/users/${userId}/comments?${params}`,
+      );
       return commentListResponseSchema.parse(response.data);
     },
     initialPageParam: undefined as number | undefined,

--- a/src/entities/comment/api/useRecentComments.ts
+++ b/src/entities/comment/api/useRecentComments.ts
@@ -6,7 +6,11 @@ import {
 
 import { apiClient } from "~/shared/api/client";
 
-import { commentListResponseSchema, type CommentListResponse } from "../model/schema";
+import {
+  commentListResponseSchema,
+  type CommentListResponse,
+} from "../model/schema";
+import { commentKeys } from "./keys";
 
 interface UseRecentCommentsParams {
   limit: number;
@@ -19,7 +23,7 @@ export function useRecentComments({
   Error
 > {
   return useInfiniteQuery({
-    queryKey: ["comments", { limit }],
+    queryKey: commentKeys.recent({ limit }),
     queryFn: async ({ pageParam }) => {
       const params = new URLSearchParams({ limit: String(limit) });
       if (pageParam !== undefined) params.set("cursor", String(pageParam));

--- a/src/entities/comment/index.ts
+++ b/src/entities/comment/index.ts
@@ -1,6 +1,11 @@
-export { commentListResponseSchema, commentSchema, writerSchema } from "./model/schema";
+export {
+  commentListResponseSchema,
+  commentSchema,
+  writerSchema,
+} from "./model/schema";
 export type { Comment, CommentListResponse, Writer } from "./model/schema";
 
+export { commentKeys } from "./api/keys";
 export { useEpigramComments } from "./api/useEpigramComments";
 export { useMyComments } from "./api/useMyComments";
 export { useRecentComments } from "./api/useRecentComments";

--- a/src/entities/emotion-log/api/keys.ts
+++ b/src/entities/emotion-log/api/keys.ts
@@ -1,0 +1,6 @@
+export const emotionLogKeys = {
+  all: ["emotionLogs"] as const,
+  today: (userId: number) => ["emotionLogs", "today", userId] as const,
+  monthly: (userId: number, year: number, month: number) =>
+    ["emotionLogs", "monthly", userId, year, month] as const,
+};

--- a/src/entities/emotion-log/api/useMonthlyEmotions.ts
+++ b/src/entities/emotion-log/api/useMonthlyEmotions.ts
@@ -3,6 +3,7 @@ import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { apiClient } from "~/shared/api/client";
 
 import { emotionLogArraySchema, type EmotionLog } from "../model/schema";
+import { emotionLogKeys } from "./keys";
 
 interface UseMonthlyEmotionsParams {
   userId: number;
@@ -16,7 +17,7 @@ export function useMonthlyEmotions({
   month,
 }: UseMonthlyEmotionsParams): UseQueryResult<EmotionLog[], Error> {
   return useQuery({
-    queryKey: ["emotionLogs", "monthly", userId, year, month],
+    queryKey: emotionLogKeys.monthly(userId, year, month),
     enabled: userId > 0,
     queryFn: async () => {
       const response = await apiClient.get<unknown>("/emotionLogs/monthly", {

--- a/src/entities/emotion-log/api/useTodayEmotion.ts
+++ b/src/entities/emotion-log/api/useTodayEmotion.ts
@@ -3,16 +3,20 @@ import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { apiClient } from "~/shared/api/client";
 
 import { emotionLogSchema, type EmotionLog } from "../model/schema";
+import { emotionLogKeys } from "./keys";
 
-export function useTodayEmotion(userId: number): UseQueryResult<EmotionLog | null, Error> {
+export function useTodayEmotion(
+  userId: number,
+): UseQueryResult<EmotionLog | null, Error> {
   return useQuery({
-    queryKey: ["emotionLogs", "today", userId],
+    queryKey: emotionLogKeys.today(userId),
     enabled: userId > 0,
     queryFn: async () => {
       const response = await apiClient.get<unknown>("/emotionLogs/today", {
         params: { userId },
       });
-      if (response.data == null || typeof response.data !== "object") return null;
+      if (response.data == null || typeof response.data !== "object")
+        return null;
       return emotionLogSchema.parse(response.data);
     },
   });

--- a/src/entities/emotion-log/index.ts
+++ b/src/entities/emotion-log/index.ts
@@ -1,6 +1,11 @@
-export { emotionLogArraySchema, emotionLogSchema, emotionSchema } from "./model/schema";
+export {
+  emotionLogArraySchema,
+  emotionLogSchema,
+  emotionSchema,
+} from "./model/schema";
 export type { Emotion, EmotionLog } from "./model/schema";
 
+export { emotionLogKeys } from "./api/keys";
 export { postTodayEmotion } from "./api/postTodayEmotion";
 export { useMonthlyEmotions } from "./api/useMonthlyEmotions";
 export { useTodayEmotion } from "./api/useTodayEmotion";

--- a/src/entities/epigram/api/keys.ts
+++ b/src/entities/epigram/api/keys.ts
@@ -1,0 +1,13 @@
+interface EpigramListParams {
+  limit: number;
+  keyword?: string;
+  writerId?: number;
+}
+
+export const epigramKeys = {
+  all: ["epigrams"] as const,
+  detail: (id: number) => ["epigrams", id] as const,
+  today: () => ["epigrams", "today"] as const,
+  list: (params: EpigramListParams) => ["epigrams", params] as const,
+  search: (keyword: string) => ["search", "epigrams", keyword] as const,
+};

--- a/src/entities/epigram/api/useEpigramDetail.ts
+++ b/src/entities/epigram/api/useEpigramDetail.ts
@@ -3,10 +3,13 @@ import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { apiClient } from "~/shared/api/client";
 
 import { epigramDetailSchema, type EpigramDetail } from "../model/schema";
+import { epigramKeys } from "./keys";
 
-export function useEpigramDetail(id: number): UseQueryResult<EpigramDetail, Error> {
+export function useEpigramDetail(
+  id: number,
+): UseQueryResult<EpigramDetail, Error> {
   return useQuery({
-    queryKey: ["epigrams", id],
+    queryKey: epigramKeys.detail(id),
     enabled: id > 0,
     queryFn: async () => {
       const response = await apiClient.get<unknown>(`/epigrams/${id}`);

--- a/src/entities/epigram/api/useEpigrams.ts
+++ b/src/entities/epigram/api/useEpigrams.ts
@@ -6,7 +6,11 @@ import {
 
 import { apiClient } from "~/shared/api/client";
 
-import { epigramListResponseSchema, type EpigramListResponse } from "../model/schema";
+import {
+  epigramListResponseSchema,
+  type EpigramListResponse,
+} from "../model/schema";
+import { epigramKeys } from "./keys";
 
 interface UseEpigramsParams {
   limit: number;
@@ -23,7 +27,7 @@ export function useEpigrams({
   Error
 > {
   return useInfiniteQuery({
-    queryKey: ["epigrams", { limit, keyword, writerId }],
+    queryKey: epigramKeys.list({ limit, keyword, writerId }),
     queryFn: async ({ pageParam }) => {
       const params = new URLSearchParams({ limit: String(limit) });
       if (pageParam !== undefined) params.set("cursor", String(pageParam));

--- a/src/entities/epigram/api/useSearchEpigrams.ts
+++ b/src/entities/epigram/api/useSearchEpigrams.ts
@@ -6,7 +6,11 @@ import {
 
 import { apiClient } from "~/shared/api/client";
 
-import { epigramListResponseSchema, type EpigramListResponse } from "../model/schema";
+import {
+  epigramListResponseSchema,
+  type EpigramListResponse,
+} from "../model/schema";
+import { epigramKeys } from "./keys";
 
 interface UseSearchEpigramsParams {
   keyword: string;
@@ -21,7 +25,7 @@ export function useSearchEpigrams({
   Error
 > {
   return useInfiniteQuery({
-    queryKey: ["search", "epigrams", keyword],
+    queryKey: epigramKeys.search(keyword),
     queryFn: async ({ pageParam }) => {
       const params = new URLSearchParams({ limit: String(limit), keyword });
       if (pageParam !== undefined) params.set("cursor", String(pageParam));

--- a/src/entities/epigram/api/useTodayEpigram.ts
+++ b/src/entities/epigram/api/useTodayEpigram.ts
@@ -3,15 +3,17 @@ import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { apiClient } from "~/shared/api/client";
 
 import { epigramSchema, type Epigram } from "../model/schema";
+import { epigramKeys } from "./keys";
 
 // /today 엔드포인트는 인증 없는 공개 API라 isLiked를 반환하지 않음.
 // swagger의 EpigramDetailType 명세와 실제 응답이 불일치하므로 epigramSchema를 사용한다.
 export function useTodayEpigram(): UseQueryResult<Epigram | null, Error> {
   return useQuery({
-    queryKey: ["epigrams", "today"],
+    queryKey: epigramKeys.today(),
     queryFn: async () => {
       const response = await apiClient.get<unknown>("/epigrams/today");
-      if (response.data == null || typeof response.data !== "object") return null;
+      if (response.data == null || typeof response.data !== "object")
+        return null;
       return epigramSchema.parse(response.data);
     },
   });

--- a/src/entities/epigram/index.ts
+++ b/src/entities/epigram/index.ts
@@ -4,10 +4,16 @@ export {
   epigramSchema,
   epigramTagSchema,
 } from "./model/schema";
-export type { Epigram, EpigramDetail, EpigramListResponse, EpigramTag } from "./model/schema";
+export type {
+  Epigram,
+  EpigramDetail,
+  EpigramListResponse,
+  EpigramTag,
+} from "./model/schema";
 
 export { createEpigram } from "./api/createEpigram";
 export type { CreateEpigramRequest } from "./api/createEpigram";
+export { epigramKeys } from "./api/keys";
 export { useEpigramDetail } from "./api/useEpigramDetail";
 export { useEpigrams } from "./api/useEpigrams";
 export { useSearchEpigrams } from "./api/useSearchEpigrams";

--- a/src/entities/user/api/keys.ts
+++ b/src/entities/user/api/keys.ts
@@ -1,0 +1,3 @@
+export const userKeys = {
+  me: () => ["me"] as const,
+};

--- a/src/entities/user/api/useMe.ts
+++ b/src/entities/user/api/useMe.ts
@@ -1,11 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { type User } from "../model/schema";
+import { userKeys } from "./keys";
 import { getMe } from "./user";
 
 export function useMe(): { user: User | null; isLoading: boolean } {
   const { data, isLoading } = useQuery<User | null, Error>({
-    queryKey: ["me"],
+    queryKey: userKeys.me(),
     queryFn: getMe,
     retry: false,
     staleTime: Infinity,

--- a/src/entities/user/index.ts
+++ b/src/entities/user/index.ts
@@ -13,4 +13,5 @@ export { signInKakao } from "./api/kakao";
 export type { SignInKakaoBody } from "./api/kakao";
 export { getMe, updateMe } from "./api/user";
 export type { UpdateMeBody } from "./api/user";
+export { userKeys } from "./api/keys";
 export { useMe } from "./api/useMe";

--- a/src/features/auth/ui/GuestLoginButton.tsx
+++ b/src/features/auth/ui/GuestLoginButton.tsx
@@ -3,7 +3,7 @@ import { router } from "expo-router";
 import { useState, type ReactElement } from "react";
 import { ActivityIndicator, Pressable, Text, View } from "react-native";
 
-import { signIn } from "~/entities/user";
+import { signIn, userKeys } from "~/entities/user";
 import { cn } from "~/shared/lib/cn";
 
 const GUEST_CREDENTIALS = {
@@ -21,7 +21,7 @@ export function GuestLoginButton(): ReactElement {
     setError(null);
     try {
       const { user } = await signIn(GUEST_CREDENTIALS);
-      queryClient.setQueryData(["me"], user);
+      queryClient.setQueryData(userKeys.me(), user);
       router.replace("/feeds");
     } catch {
       setError("게스트 로그인에 실패했습니다. 잠시 후 다시 시도해주세요.");

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -5,7 +5,7 @@ import type { ReactElement } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { View } from "react-native";
 
-import { signIn } from "~/entities/user";
+import { signIn, userKeys } from "~/entities/user";
 import { Button, Input } from "~/shared/ui";
 
 import { loginSchema, type LoginFormValues } from "../model/loginSchema";
@@ -28,7 +28,7 @@ export function LoginForm(): ReactElement {
   async function onSubmit(data: LoginFormValues): Promise<void> {
     try {
       const { user } = await signIn(data);
-      queryClient.setQueryData(["me"], user);
+      queryClient.setQueryData(userKeys.me(), user);
       router.replace("/feeds");
     } catch {
       const message = "이메일 혹은 비밀번호를 확인해주세요.";

--- a/src/features/auth/ui/SignUpForm.tsx
+++ b/src/features/auth/ui/SignUpForm.tsx
@@ -6,7 +6,7 @@ import type { ReactElement } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { View } from "react-native";
 
-import { signUp } from "~/entities/user";
+import { signUp, userKeys } from "~/entities/user";
 import { Button, Input } from "~/shared/ui";
 
 import { signUpSchema, type SignUpFormValues } from "../model/signUpSchema";
@@ -34,14 +34,16 @@ export function SignUpForm(): ReactElement {
   async function onSubmit(data: SignUpFormValues): Promise<void> {
     try {
       const { user } = await signUp(data);
-      queryClient.setQueryData(["me"], user);
+      queryClient.setQueryData(userKeys.me(), user);
       router.replace("/feeds");
     } catch (error) {
       if (isAxiosError(error) && error.response?.status === 500) {
         setError("nickname", { message: "이미 사용 중인 닉네임입니다." });
         return;
       }
-      setError("email", { message: "회원가입에 실패했습니다. 다시 시도해주세요." });
+      setError("email", {
+        message: "회원가입에 실패했습니다. 다시 시도해주세요.",
+      });
     }
   }
 

--- a/src/features/comment-create/model/useCommentCreate.ts
+++ b/src/features/comment-create/model/useCommentCreate.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
-import type { Comment } from "~/entities/comment";
+import { commentKeys, type Comment } from "~/entities/comment";
 import { apiClient } from "~/shared/api/client";
 
 interface CreateCommentBody {
@@ -36,7 +36,7 @@ export function useCommentCreate(epigramId: number): UseCommentCreateReturn {
       apiClient.post<Comment>("/comments", body).then((res) => res.data),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["epigrams", epigramId, "comments"],
+        queryKey: commentKeys.byEpigram(epigramId),
       });
       setContent("");
       setIsPrivate(false);

--- a/src/features/comment-delete/model/useCommentDelete.ts
+++ b/src/features/comment-delete/model/useCommentDelete.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Alert } from "react-native";
 
+import { commentKeys } from "~/entities/comment";
 import { apiClient } from "~/shared/api/client";
 
 interface UseCommentDeleteReturn {
@@ -20,11 +21,11 @@ export function useCommentDelete(
       apiClient.delete(`/comments/${commentId}`).then((res) => res.data),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["epigrams", epigramId, "comments"],
+        queryKey: commentKeys.byEpigram(epigramId),
       });
       if (userId === undefined) return;
       queryClient.invalidateQueries({
-        queryKey: ["users", userId, "comments"],
+        queryKey: commentKeys.byUser(userId),
       });
     },
     onError: () => {

--- a/src/features/comment-edit/model/useCommentEdit.ts
+++ b/src/features/comment-edit/model/useCommentEdit.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
-import type { Comment } from "~/entities/comment";
+import { commentKeys, type Comment } from "~/entities/comment";
 import { apiClient } from "~/shared/api/client";
 
 interface UpdateCommentBody {
@@ -51,7 +51,7 @@ export function useCommentEdit({
         .then((res) => res.data),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["epigrams", epigramId, "comments"],
+        queryKey: commentKeys.byEpigram(epigramId),
       });
       onCancel();
     },

--- a/src/features/epigram-like/model/useEpigramLike.ts
+++ b/src/features/epigram-like/model/useEpigramLike.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from "react";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-import type { EpigramDetail } from "~/entities/epigram";
+import { epigramKeys, type EpigramDetail } from "~/entities/epigram";
 import { apiClient } from "~/shared/api/client";
 
 interface UseEpigramLikeReturn {
@@ -12,7 +12,7 @@ interface UseEpigramLikeReturn {
 
 export function useEpigramLike(epigramId: number): UseEpigramLikeReturn {
   const queryClient = useQueryClient();
-  const queryKey = useMemo(() => ["epigrams", epigramId], [epigramId]);
+  const queryKey = useMemo(() => epigramKeys.detail(epigramId), [epigramId]);
 
   const { mutate, isPending } = useMutation({
     mutationFn: async (isCurrentlyLiked: boolean): Promise<EpigramDetail> => {


### PR DESCRIPTION
Closes #53

## Summary
14곳에 흩어져 있던 query key 리터럴을 entity 별 factory로 중앙화. 기존 캐시 키 shape는 유지해 캐시 호환성 보장.

## 변경
- 신규: `entities/{comment,epigram,user,emotion-log}/api/keys.ts`
- 모든 `useQuery` / `useInfiniteQuery` queryKey를 factory 호출로 교체
- `setQueryData(["me"], …)` 3곳, `invalidateQueries({queryKey: [...]})` 4곳도 factory 경유

## 비범위
- 댓글 mutation API entity 레이어 분리 — 별도 PR

## Test plan
- [ ] CI typecheck/lint 통과
- [ ] 로그인/회원가입/게스트 진입 시 me 캐시 정상 갱신
- [ ] 댓글 생성/수정/삭제 후 목록 invalidate 동작
- [ ] 좋아요 optimistic update 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)