### PR TITLE
refactor: 댓글 mutation API를 entity 레이어로 분리 (#55)

### DIFF
--- a/src/entities/comment/api/mutations.ts
+++ b/src/entities/comment/api/mutations.ts
@@ -1,0 +1,34 @@
+import { apiClient } from "~/shared/api/client";
+
+import type { Comment } from "../model/schema";
+
+export interface CreateCommentBody {
+  epigramId: number;
+  isPrivate: boolean;
+  content: string;
+}
+
+export interface UpdateCommentBody {
+  isPrivate?: boolean;
+  content?: string;
+}
+
+export async function createComment(body: CreateCommentBody): Promise<Comment> {
+  const response = await apiClient.post<Comment>("/comments", body);
+  return response.data;
+}
+
+export async function updateComment(
+  commentId: number,
+  body: UpdateCommentBody,
+): Promise<Comment> {
+  const response = await apiClient.patch<Comment>(
+    `/comments/${commentId}`,
+    body,
+  );
+  return response.data;
+}
+
+export async function deleteComment(commentId: number): Promise<void> {
+  await apiClient.delete(`/comments/${commentId}`);
+}

--- a/src/entities/comment/index.ts
+++ b/src/entities/comment/index.ts
@@ -6,6 +6,8 @@ export {
 export type { Comment, CommentListResponse, Writer } from "./model/schema";
 
 export { commentKeys } from "./api/keys";
+export { createComment, deleteComment, updateComment } from "./api/mutations";
+export type { CreateCommentBody, UpdateCommentBody } from "./api/mutations";
 export { useEpigramComments } from "./api/useEpigramComments";
 export { useMyComments } from "./api/useMyComments";
 export { useRecentComments } from "./api/useRecentComments";

--- a/src/features/comment-create/model/useCommentCreate.ts
+++ b/src/features/comment-create/model/useCommentCreate.ts
@@ -1,14 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
-import { commentKeys, type Comment } from "~/entities/comment";
-import { apiClient } from "~/shared/api/client";
-
-interface CreateCommentBody {
-  epigramId: number;
-  isPrivate: boolean;
-  content: string;
-}
+import { commentKeys, createComment } from "~/entities/comment";
 
 interface UseCommentCreateReturn {
   content: string;
@@ -32,8 +25,7 @@ export function useCommentCreate(epigramId: number): UseCommentCreateReturn {
     isError: hasError,
     reset,
   } = useMutation({
-    mutationFn: (body: CreateCommentBody) =>
-      apiClient.post<Comment>("/comments", body).then((res) => res.data),
+    mutationFn: createComment,
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: commentKeys.byEpigram(epigramId),

--- a/src/features/comment-delete/model/useCommentDelete.ts
+++ b/src/features/comment-delete/model/useCommentDelete.ts
@@ -1,8 +1,10 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Alert } from "react-native";
 
-import { commentKeys } from "~/entities/comment";
-import { apiClient } from "~/shared/api/client";
+import {
+  commentKeys,
+  deleteComment as deleteCommentApi,
+} from "~/entities/comment";
 
 interface UseCommentDeleteReturn {
   deleteComment: () => void;
@@ -17,8 +19,7 @@ export function useCommentDelete(
   const queryClient = useQueryClient();
 
   const { mutate, isPending: isDeleting } = useMutation({
-    mutationFn: () =>
-      apiClient.delete(`/comments/${commentId}`).then((res) => res.data),
+    mutationFn: () => deleteCommentApi(commentId),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: commentKeys.byEpigram(epigramId),

--- a/src/features/comment-edit/model/useCommentEdit.ts
+++ b/src/features/comment-edit/model/useCommentEdit.ts
@@ -1,13 +1,11 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
-import { commentKeys, type Comment } from "~/entities/comment";
-import { apiClient } from "~/shared/api/client";
-
-interface UpdateCommentBody {
-  isPrivate?: boolean;
-  content?: string;
-}
+import {
+  commentKeys,
+  updateComment,
+  type UpdateCommentBody,
+} from "~/entities/comment";
 
 interface UseCommentEditParams {
   commentId: number;
@@ -45,10 +43,7 @@ export function useCommentEdit({
     isPending: isSubmitting,
     isError: hasError,
   } = useMutation({
-    mutationFn: (body: UpdateCommentBody) =>
-      apiClient
-        .patch<Comment>(`/comments/${commentId}`, body)
-        .then((res) => res.data),
+    mutationFn: (body: UpdateCommentBody) => updateComment(commentId, body),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: commentKeys.byEpigram(epigramId),


### PR DESCRIPTION
Closes #55

## Summary
댓글 CRUD의 HTTP 호출을 `entities/comment/api/mutations.ts`로 옮기고, feature 훅은 React Query 상태/캐시 invalidation만 담당하도록 단순화. FSD 레이어 책임에 부합.

## 변경
- 신규: `entities/comment/api/mutations.ts` — `createComment`, `updateComment`, `deleteComment` + `CreateCommentBody`, `UpdateCommentBody` 타입
- `useCommentCreate` / `useCommentEdit` / `useCommentDelete`에서 `apiClient` import 제거
- entity index에 mutations · 타입 export 추가

## 비범위
- 좋아요 mutation 분리 — 별도 이슈 (optimistic update 결합 부분 별도 검토)

## Test plan
- [ ] CI typecheck/lint 통과
- [ ] 댓글 작성/수정/삭제 후 목록 갱신 정상
- [ ] 삭제 실패 시 Alert 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)