### PR TITLE
refactor: 댓글 수정 폼의 에러 클리어 동작을 작성 폼과 일관화

### DIFF
--- a/src/features/comment-edit/model/useCommentEdit.ts
+++ b/src/features/comment-edit/model/useCommentEdit.ts
@@ -21,7 +21,7 @@ interface UseCommentEditReturn {
   isSubmitting: boolean;
   hasError: boolean;
   canSubmit: boolean;
-  setContent: (value: string) => void;
+  handleContentChange: (value: string) => void;
   handlePrivateToggle: () => void;
   handleSubmit: () => void;
   handleCancel: () => void;
@@ -42,6 +42,7 @@ export function useCommentEdit({
     mutate,
     isPending: isSubmitting,
     isError: hasError,
+    reset,
   } = useMutation({
     mutationFn: (body: UpdateCommentBody) => updateComment(commentId, body),
     onSuccess: () => {
@@ -53,6 +54,11 @@ export function useCommentEdit({
   });
 
   const canSubmit = content.trim().length > 0;
+
+  function handleContentChange(value: string): void {
+    setContent(value);
+    if (hasError) reset();
+  }
 
   function handlePrivateToggle(): void {
     setIsPrivate((prev) => !prev);
@@ -76,7 +82,7 @@ export function useCommentEdit({
     isSubmitting,
     hasError,
     canSubmit,
-    setContent,
+    handleContentChange,
     handlePrivateToggle,
     handleSubmit,
     handleCancel,

--- a/src/features/comment-edit/ui/CommentEditForm.tsx
+++ b/src/features/comment-edit/ui/CommentEditForm.tsx
@@ -28,7 +28,7 @@ export function CommentEditForm({
     isSubmitting,
     hasError,
     canSubmit,
-    setContent,
+    handleContentChange,
     handlePrivateToggle,
     handleSubmit,
     handleCancel,
@@ -44,7 +44,7 @@ export function CommentEditForm({
     <View className="gap-2 rounded-2xl border border-blue-400 bg-white p-3">
       <TextInput
         value={content}
-        onChangeText={setContent}
+        onChangeText={handleContentChange}
         maxLength={MAX_LENGTH}
         multiline
         numberOfLines={2}


### PR DESCRIPTION
## 작업 내용
댓글 작성 폼은 입력값이 바뀌면 mutation의 `reset()`을 호출해 이전 에러 메시지를 자동으로 지운다(`useCommentCreate`). 댓글 수정 폼은 이 동작이 없어 한 번 에러가 뜨면 사용자가 글자를 다시 입력해도 에러 메시지가 그대로 남는다.

같은 입력 폼이 다르게 동작하던 비대칭을 정리한다.

- `useCommentEdit`이 `setContent` 대신 `handleContentChange`를 노출
- `handleContentChange`에서 `hasError`일 때 `reset()` 호출
- `CommentEditForm`의 `onChangeText`를 `handleContentChange`로 교체

## 영향 범위
- `src/features/comment-edit/model/useCommentEdit.ts`
- `src/features/comment-edit/ui/CommentEditForm.tsx`

Closes #61