### PR TITLE
feat: 최근 검색어 저장 훅 추가 (#63)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@expo-google-fonts/nanum-myeongjo": "^0.4.1",
         "@expo/vector-icons": "^15.0.3",
         "@hookform/resolvers": "^5.2.2",
+        "@react-native-async-storage/async-storage": "2.2.0",
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
@@ -3395,6 +3396,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -8554,6 +8567,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -9590,6 +9612,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@expo-google-fonts/nanum-myeongjo": "^0.4.1",
     "@expo/vector-icons": "^15.0.3",
     "@hookform/resolvers": "^5.2.2",
+    "@react-native-async-storage/async-storage": "2.2.0",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",

--- a/src/features/epigram-search/index.ts
+++ b/src/features/epigram-search/index.ts
@@ -1,0 +1,1 @@
+export { useRecentSearches } from "./model/useRecentSearches";

--- a/src/features/epigram-search/model/useRecentSearches.ts
+++ b/src/features/epigram-search/model/useRecentSearches.ts
@@ -1,0 +1,72 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY = "epigram_recent_searches";
+const MAX_RECENT_SEARCHES = 10;
+
+interface UseRecentSearchesResult {
+  recentSearches: string[];
+  addRecentSearch: (keyword: string) => void;
+  clearAllRecentSearches: () => void;
+}
+
+function parseStored(raw: string | null): string[] | null {
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    if (!parsed.every((item) => typeof item === "string")) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function useRecentSearches(): UseRecentSearchesResult {
+  const [recentSearches, setRecentSearches] = useState<string[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    AsyncStorage.getItem(STORAGE_KEY)
+      .then((raw) => {
+        if (cancelled) return;
+        const parsed = parseStored(raw);
+        if (parsed) setRecentSearches(parsed);
+      })
+      .catch(() => {
+        // 읽기 실패는 빈 배열로 폴백
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const persist = useCallback((next: string[]): void => {
+    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next)).catch(() => {
+      // 저장 실패는 다음 기회로 미룸
+    });
+  }, []);
+
+  const addRecentSearch = useCallback(
+    (keyword: string): void => {
+      const trimmed = keyword.trim();
+      if (!trimmed) return;
+      setRecentSearches((prev) => {
+        const next = [trimmed, ...prev.filter((k) => k !== trimmed)].slice(
+          0,
+          MAX_RECENT_SEARCHES,
+        );
+        persist(next);
+        return next;
+      });
+    },
+    [persist],
+  );
+
+  const clearAllRecentSearches = useCallback((): void => {
+    setRecentSearches([]);
+    persist([]);
+  }, [persist]);
+
+  return { recentSearches, addRecentSearch, clearAllRecentSearches };
+}


### PR DESCRIPTION
Refs #63

## Summary
검색 페이지의 최근 검색어 저장 인프라. AsyncStorage에 영속화하는 `useRecentSearches` 훅과 SDK 54 호환 버전 설치.

## 변경
- `@react-native-async-storage/async-storage` 2.2.0 (Expo install)
- `features/epigram-search/model/useRecentSearches.ts`
  - 마운트 시 AsyncStorage에서 비동기 로드 (cancelled 가드로 unmount 후 setState 방지)
  - `addRecentSearch(keyword)` — trim → dedup → 맨 앞 삽입 → 10개로 자르기
  - `clearAllRecentSearches()` — state·storage 동시 비우기
  - 손상된 JSON / Array 아닌 값 / 비-string 요소는 안전하게 무시
- `features/epigram-search/index.ts` — 퍼블릭 API export

## 비범위
- `useSearch`, `SearchBar`, `SearchResultItem`, `SearchScreen` — 후속 PR (#63 워크 분할)

## Test plan
- [ ] CI typecheck/lint 통과
- [ ] 후속 PR에서 SearchBar 통합 후 추가/삭제/재시작 시나리오 수동 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)
