### PR TITLE
feat: 검색 훅·UI 컴포넌트 추가 (#63)

### DIFF
--- a/src/features/epigram-search/index.ts
+++ b/src/features/epigram-search/index.ts
@@ -1,1 +1,4 @@
 export { useRecentSearches } from "./model/useRecentSearches";
+export { useSearch } from "./model/useSearch";
+export { SearchBar } from "./ui/SearchBar";
+export { SearchResultItem } from "./ui/SearchResultItem";

--- a/src/features/epigram-search/model/useSearch.ts
+++ b/src/features/epigram-search/model/useSearch.ts
@@ -1,0 +1,43 @@
+import { useCallback, useState } from "react";
+
+import { useRecentSearches } from "./useRecentSearches";
+
+interface UseSearchResult {
+  inputValue: string;
+  activeKeyword: string;
+  recentSearches: string[];
+  handleInputChange: (value: string) => void;
+  handleSearch: (keyword: string) => void;
+  clearAllRecentSearches: () => void;
+}
+
+export function useSearch(): UseSearchResult {
+  const [inputValue, setInputValue] = useState("");
+  const [activeKeyword, setActiveKeyword] = useState("");
+  const { recentSearches, addRecentSearch, clearAllRecentSearches } =
+    useRecentSearches();
+
+  const handleInputChange = useCallback((value: string): void => {
+    setInputValue(value);
+  }, []);
+
+  const handleSearch = useCallback(
+    (keyword: string): void => {
+      const trimmed = keyword.trim();
+      if (!trimmed) return;
+      setInputValue(trimmed);
+      setActiveKeyword(trimmed);
+      addRecentSearch(trimmed);
+    },
+    [addRecentSearch],
+  );
+
+  return {
+    inputValue,
+    activeKeyword,
+    recentSearches,
+    handleInputChange,
+    handleSearch,
+    clearAllRecentSearches,
+  };
+}

--- a/src/features/epigram-search/ui/SearchBar.tsx
+++ b/src/features/epigram-search/ui/SearchBar.tsx
@@ -1,0 +1,102 @@
+import { Search } from "lucide-react-native";
+import { type ReactElement } from "react";
+import { Pressable, Text, TextInput, View } from "react-native";
+
+interface SearchBarProps {
+  inputValue: string;
+  recentSearches: string[];
+  onInputChange: (value: string) => void;
+  onSearch: (keyword: string) => void;
+  onClearAllRecent: () => void;
+}
+
+interface RecentSearchChipProps {
+  keyword: string;
+  onSelect: (keyword: string) => void;
+}
+
+function RecentSearchChip({
+  keyword,
+  onSelect,
+}: RecentSearchChipProps): ReactElement {
+  function handlePress(): void {
+    onSelect(keyword);
+  }
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      accessibilityRole="button"
+      accessibilityLabel={`최근 검색어 ${keyword}로 검색`}
+      className="rounded-full bg-blue-200 px-3 py-1.5 active:bg-blue-300"
+    >
+      <Text className="font-sans text-sm text-black-600">{keyword}</Text>
+    </Pressable>
+  );
+}
+
+export function SearchBar({
+  inputValue,
+  recentSearches,
+  onInputChange,
+  onSearch,
+  onClearAllRecent,
+}: SearchBarProps): ReactElement {
+  function handleSubmit(): void {
+    onSearch(inputValue);
+  }
+
+  return (
+    <View className="w-full gap-6">
+      <View className="flex-row items-center border-b-2 border-blue-300 pb-2">
+        <TextInput
+          value={inputValue}
+          onChangeText={onInputChange}
+          onSubmitEditing={handleSubmit}
+          returnKeyType="search"
+          placeholder="검색어를 입력하세요"
+          placeholderTextColor="#abb8ce"
+          autoCorrect={false}
+          autoCapitalize="none"
+          className="h-10 flex-1 font-sans text-base text-black-900"
+        />
+        <Pressable
+          onPress={handleSubmit}
+          accessibilityRole="button"
+          accessibilityLabel="검색"
+          className="ml-2 h-10 w-10 items-center justify-center active:opacity-70"
+        >
+          <Search size={20} color="#abb8ce" />
+        </Pressable>
+      </View>
+
+      {recentSearches.length > 0 && (
+        <View className="gap-3">
+          <View className="flex-row items-center justify-between">
+            <Text className="font-sans text-sm font-semibold text-black-600">
+              최근 검색어
+            </Text>
+            <Pressable
+              onPress={onClearAllRecent}
+              accessibilityRole="button"
+              className="active:opacity-70"
+            >
+              <Text className="font-sans text-xs text-blue-400">
+                모두 지우기
+              </Text>
+            </Pressable>
+          </View>
+          <View className="flex-row flex-wrap gap-2">
+            {recentSearches.map((keyword) => (
+              <RecentSearchChip
+                key={keyword}
+                keyword={keyword}
+                onSelect={onSearch}
+              />
+            ))}
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/src/features/epigram-search/ui/SearchResultItem.tsx
+++ b/src/features/epigram-search/ui/SearchResultItem.tsx
@@ -1,0 +1,126 @@
+import { router } from "expo-router";
+import { memo, type ReactElement, useMemo } from "react";
+import { Pressable, Text, View } from "react-native";
+
+import type { Epigram } from "~/entities/epigram";
+
+interface SearchResultItemProps {
+  epigram: Epigram;
+  keyword: string;
+}
+
+interface HighlightedSegment {
+  text: string;
+  isMatch: boolean;
+}
+
+function buildSegments(text: string, regex: RegExp): HighlightedSegment[] {
+  // split alternates: even indices are plain, odd indices are matched groups
+  return text.split(regex).map((part, index) => ({
+    text: part,
+    isMatch: index % 2 === 1,
+  }));
+}
+
+interface HighlightedTextProps {
+  text: string;
+  keyword: string;
+  className: string;
+  highlightClassName: string;
+}
+
+function HighlightedText({
+  text,
+  keyword,
+  className,
+  highlightClassName,
+}: HighlightedTextProps): ReactElement {
+  const regex = useMemo(() => {
+    if (!keyword.trim()) return null;
+    const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`(${escaped})`, "i");
+  }, [keyword]);
+
+  if (!regex) return <Text className={className}>{text}</Text>;
+
+  return (
+    <Text className={className}>
+      {buildSegments(text, regex).map((segment, index) =>
+        segment.isMatch ? (
+          <Text key={index} className={highlightClassName}>
+            {segment.text}
+          </Text>
+        ) : (
+          segment.text
+        ),
+      )}
+    </Text>
+  );
+}
+
+interface TagListProps {
+  tags: Epigram["tags"];
+  keyword: string;
+}
+
+function TagList({ tags, keyword }: TagListProps): ReactElement | null {
+  if (tags.length === 0) return null;
+
+  return (
+    <View
+      className="flex-row flex-wrap gap-x-3 gap-y-1"
+      accessibilityLabel="태그 목록"
+    >
+      {tags.map((tag) => (
+        <Text key={tag.id} className="font-sans text-sm text-blue-500">
+          #
+          <HighlightedText
+            text={tag.name}
+            keyword={keyword}
+            className="font-sans text-sm text-blue-500"
+            highlightClassName="font-semibold text-illust-blue"
+          />
+        </Text>
+      ))}
+    </View>
+  );
+}
+
+function SearchResultItemBase({
+  epigram,
+  keyword,
+}: SearchResultItemProps): ReactElement {
+  const authorLabel = epigram.referenceTitle
+    ? `${epigram.author} 《${epigram.referenceTitle}》`
+    : epigram.author;
+
+  function handlePress(): void {
+    router.push(`/epigrams/${epigram.id}`);
+  }
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      accessibilityRole="button"
+      className="border-b border-line-100 py-5 active:bg-blue-200/40"
+    >
+      <View className="gap-4">
+        <View className="gap-3">
+          <HighlightedText
+            text={epigram.content}
+            keyword={keyword}
+            className="font-serif text-base text-black-700"
+            highlightClassName="font-semibold text-illust-blue"
+          />
+          <Text className="font-serif text-sm text-blue-500">
+            - {authorLabel} -
+          </Text>
+        </View>
+
+        <TagList tags={epigram.tags} keyword={keyword} />
+      </View>
+    </Pressable>
+  );
+}
+
+export const SearchResultItem = memo(SearchResultItemBase);


### PR DESCRIPTION
Refs #63

## Summary
검색 페이지 화면 조립의 재료가 되는 훅과 UI 컴포넌트. 다음 PR에서 `SearchScreen`이 이들을 조합한다.

## 변경
- `model/useSearch` — `inputValue`/`activeKeyword` 분리. 웹의 URL 동기화는 RN에 부적합 → 내부 state로 단순화. 검색 실행 시 trim → state 갱신 → `useRecentSearches.addRecentSearch` 호출
- `ui/SearchBar`
  - `TextInput.onSubmitEditing` (returnKeyType="search") + 우측 검색 아이콘 버튼 — 두 경로 모두 `onSearch` 위임
  - 최근 검색어 영역: 헤더 + "모두 지우기" + flex-wrap 칩
  - 칩 탭으로 즉시 재검색 (웹과 동일하게 개별 삭제 X)
- `ui/SearchResultItem`
  - `Pressable` → `router.push("/epigrams/{id}")`
  - 키워드 하이라이트: regex split → `Text` 안에 nested 강조 `Text` (mark 대체). 정규식 특수문자 escape, 빈 키워드는 plain text fallback
  - 태그/본문 모두 하이라이트, 작품명 있으면 `《제목》` 결합
  - `memo` 적용 (FlatList 최적화 대비)

## 비범위
- `SearchScreen` 페이지 + 탭 와이어업 — 후속 PR

## Test plan
- [ ] CI typecheck/lint 통과
- [ ] (후속 PR 통합 후) 한글/영어 키워드 하이라이트 정확성, 칩 재검색, 모두 지우기 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)
