### PR TITLE
feat: 검색 화면 구현 및 탭 와이어업 (#63)

### DIFF
--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -1,13 +1,5 @@
-import { Text, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SearchScreen } from "~/views/search";
 
-export default function SearchScreen() {
-  return (
-    <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 items-center justify-center px-screen-x">
-        <Text className="font-sans text-2xl font-bold text-black-900">검색</Text>
-        <Text className="mt-2 font-sans text-sm text-blue-400">에피그램·태그 검색</Text>
-      </View>
-    </SafeAreaView>
-  );
+export default function Search() {
+  return <SearchScreen />;
 }

--- a/src/views/search/index.ts
+++ b/src/views/search/index.ts
@@ -1,0 +1,1 @@
+export { SearchScreen } from "./ui/SearchScreen";

--- a/src/views/search/ui/SearchScreen.tsx
+++ b/src/views/search/ui/SearchScreen.tsx
@@ -1,0 +1,203 @@
+import { SearchX } from "lucide-react-native";
+import { useCallback, useMemo, type ReactElement } from "react";
+import {
+  ActivityIndicator,
+  FlatList,
+  Keyboard,
+  Text,
+  View,
+  type ListRenderItem,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { useSearchEpigrams, type Epigram } from "~/entities/epigram";
+import {
+  SearchBar,
+  SearchResultItem,
+  useSearch,
+} from "~/features/epigram-search";
+
+const SEARCH_LIMIT = 10;
+
+function SearchResultSkeletonItem(): ReactElement {
+  return (
+    <View className="border-b border-line-100 py-5">
+      <View className="gap-2.5">
+        <View className="h-3.5 w-4/5 rounded-md bg-blue-200" />
+        <View className="h-3.5 w-1/2 rounded-md bg-blue-200" />
+        <View className="flex-row gap-2 pt-1">
+          <View className="h-5 w-14 rounded-full bg-blue-200" />
+          <View className="h-5 w-20 rounded-full bg-blue-200" />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function SearchResultSkeleton(): ReactElement {
+  return (
+    <View>
+      {Array.from({ length: 4 }).map((_, i) => (
+        <SearchResultSkeletonItem key={i} />
+      ))}
+    </View>
+  );
+}
+
+interface SearchNoResultsProps {
+  keyword: string;
+}
+
+function SearchNoResults({ keyword }: SearchNoResultsProps): ReactElement {
+  return (
+    <View className="items-center gap-5 py-24">
+      <View className="h-16 w-16 items-center justify-center rounded-full bg-blue-200">
+        <SearchX size={28} color="#52698e" strokeWidth={1.5} />
+      </View>
+      <View className="items-center gap-1.5 px-screen-x">
+        <Text className="text-center font-sans text-sm text-black-600">
+          <Text className="font-semibold text-blue-700">
+            &ldquo;{keyword}&rdquo;
+          </Text>
+          에 대한 결과가 없어요
+        </Text>
+        <Text className="text-center font-sans text-xs text-black-300">
+          철자를 확인하거나 다른 검색어를 입력해 보세요
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+function InitialState(): ReactElement {
+  return (
+    <View className="items-center gap-4 py-24">
+      <Text
+        className="select-none font-serif text-7xl text-blue-300"
+        accessibilityElementsHidden
+      >
+        {"\u201C"}
+      </Text>
+      <View className="items-center gap-1.5 px-screen-x">
+        <Text className="text-center font-serif text-base text-black-500">
+          검색어를 입력해 에피그램을 찾아보세요
+        </Text>
+        <Text className="text-center font-sans text-xs text-black-300">
+          작가 이름, 글귀, 태그 모두 검색 가능합니다
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+interface SearchResultsProps {
+  keyword: string;
+}
+
+function SearchResults({ keyword }: SearchResultsProps): ReactElement {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
+    useSearchEpigrams({ keyword, limit: SEARCH_LIMIT });
+
+  const epigrams = useMemo(
+    () => data?.pages.flatMap((page) => page.list) ?? [],
+    [data?.pages],
+  );
+
+  const handleEndReached = useCallback((): void => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const renderItem: ListRenderItem<Epigram> = useCallback(
+    ({ item }) => <SearchResultItem epigram={item} keyword={keyword} />,
+    [keyword],
+  );
+
+  const headerElement = useMemo(
+    () => (
+      <Text className="mb-4 font-sans text-xs text-black-300">
+        검색 결과{" "}
+        <Text className="font-semibold text-blue-700">
+          {epigrams.length}
+          {hasNextPage ? "+" : ""}
+        </Text>
+      </Text>
+    ),
+    [epigrams.length, hasNextPage],
+  );
+
+  const footerElement = useMemo(() => {
+    if (isFetchingNextPage) {
+      return (
+        <View className="items-center py-8">
+          <ActivityIndicator color="#abb8ce" />
+        </View>
+      );
+    }
+    if (!hasNextPage && epigrams.length > 0) {
+      return (
+        <View className="items-center py-8">
+          <Text className="font-sans text-xs text-black-300">
+            모든 결과를 불러왔습니다
+          </Text>
+        </View>
+      );
+    }
+    return null;
+  }, [isFetchingNextPage, hasNextPage, epigrams.length]);
+
+  if (isLoading) return <SearchResultSkeleton />;
+  if (epigrams.length === 0) return <SearchNoResults keyword={keyword} />;
+
+  return (
+    <FlatList
+      data={epigrams}
+      keyExtractor={(item) => String(item.id)}
+      renderItem={renderItem}
+      onEndReached={handleEndReached}
+      onEndReachedThreshold={0.5}
+      ListHeaderComponent={headerElement}
+      ListFooterComponent={footerElement}
+      keyboardShouldPersistTaps="handled"
+    />
+  );
+}
+
+export function SearchScreen(): ReactElement {
+  const {
+    inputValue,
+    activeKeyword,
+    recentSearches,
+    handleInputChange,
+    handleSearch,
+    clearAllRecentSearches,
+  } = useSearch();
+
+  const handleSearchAndDismiss = useCallback(
+    (keyword: string): void => {
+      Keyboard.dismiss();
+      handleSearch(keyword);
+    },
+    [handleSearch],
+  );
+
+  return (
+    <SafeAreaView className="flex-1 bg-background" edges={["top"]}>
+      <View className="px-screen-x pt-6">
+        <SearchBar
+          inputValue={inputValue}
+          recentSearches={recentSearches}
+          onInputChange={handleInputChange}
+          onSearch={handleSearchAndDismiss}
+          onClearAllRecent={clearAllRecentSearches}
+        />
+      </View>
+      <View className="mt-8 flex-1 px-screen-x">
+        {activeKeyword ? (
+          <SearchResults keyword={activeKeyword} />
+        ) : (
+          <InitialState />
+        )}
+      </View>
+    </SafeAreaView>
+  );
+}


### PR DESCRIPTION
Closes #63

## Summary
검색 페이지 마지막 조각. 앞선 두 PR(#64 useRecentSearches, #65 useSearch + UI 컴포넌트)이 만든 재료를 조립하여 화면 완성. 탭의 placeholder 스텁을 실제 화면으로 교체.

## 변경
- `views/search/ui/SearchScreen`
  - 상단 고정 `SearchBar` + 하단 flex-1 결과 영역 (스크롤 분리)
  - 4가지 결과 상태:
    - `InitialState` — 키워드 미입력 (인용 마크 + 안내 문구)
    - `SearchResultSkeleton` — 첫 페이지 로딩 (4개 placeholder)
    - `SearchNoResults` — 결과 0건 (검색 키워드 강조 + 재입력 유도)
    - `FlatList` — 결과 ≥1건 (헤더 카운트 + 무한 스크롤 + 푸터 로딩/완료)
  - 검색 실행 시 `Keyboard.dismiss()`로 키보드 정리
  - `keyboardShouldPersistTaps="handled"` — 키보드 활성 상태에서도 결과 한 번 탭으로 진입
  - FlatList 최적화: `useMemo`로 epigrams/header/footer, `useCallback`로 renderItem/onEndReached
- `app/(tabs)/search.tsx` — 스텁 → `<SearchScreen />` 위임

## Test plan
- [ ] CI typecheck/lint/build 통과
- [ ] 키워드 입력 → Enter / 검색 버튼 클릭 → 결과 표시
- [ ] 검색 후 최근 검색어에 누적, 칩 탭으로 즉시 재검색
- [ ] "모두 지우기" → 칩 영역 사라짐 + 앱 재시작 후에도 빈 상태
- [ ] 결과 무한 스크롤 정상 (페이지 추가 로딩 시 푸터 스피너)
- [ ] 결과 카드 탭 → `/epigrams/{id}` 이동
- [ ] 한글/영어/태그 키워드 하이라이트 정확

🤖 Generated with [Claude Code](https://claude.com/claude-code)
