### PR TITLE
feat: axios 응답 인터셉터에 access token 자동 갱신 로직 추가 (#67)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,30 +1,33 @@
-import '../global.css';
+import "../global.css";
 
 import {
   NanumMyeongjo_400Regular,
   NanumMyeongjo_700Bold,
-} from '@expo-google-fonts/nanum-myeongjo';
-import { useFonts } from 'expo-font';
-import { Stack } from 'expo-router';
-import * as SplashScreen from 'expo-splash-screen';
-import { StatusBar } from 'expo-status-bar';
-import { useEffect } from 'react';
-import 'react-native-reanimated';
+} from "@expo-google-fonts/nanum-myeongjo";
+import { useFonts } from "expo-font";
+import { Stack } from "expo-router";
+import * as SplashScreen from "expo-splash-screen";
+import { StatusBar } from "expo-status-bar";
+import { useEffect } from "react";
+import "react-native-reanimated";
 
-import { QueryProvider } from '~/shared/api/QueryProvider';
+import { useSessionExpiryRedirect } from "~/features/auth";
+import { QueryProvider } from "~/shared/api/QueryProvider";
 
 SplashScreen.preventAutoHideAsync();
 
 export const unstable_settings = {
-  anchor: '(tabs)',
+  anchor: "(tabs)",
 };
 
 export default function RootLayout() {
   const [fontsLoaded, fontsError] = useFonts({
-    Pretendard: require('pretendard/dist/public/variable/PretendardVariable.ttf'),
+    Pretendard: require("pretendard/dist/public/variable/PretendardVariable.ttf"),
     NanumMyeongjo: NanumMyeongjo_400Regular,
-    'NanumMyeongjo-Bold': NanumMyeongjo_700Bold,
+    "NanumMyeongjo-Bold": NanumMyeongjo_700Bold,
   });
+
+  useSessionExpiryRedirect();
 
   useEffect(() => {
     if (fontsLoaded || fontsError) {

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -2,6 +2,7 @@ export { loginSchema } from "./model/loginSchema";
 export type { LoginFormValues } from "./model/loginSchema";
 export { signUpSchema } from "./model/signUpSchema";
 export type { SignUpFormValues } from "./model/signUpSchema";
+export { useSessionExpiryRedirect } from "./model/useSessionExpiryRedirect";
 
 export { GuestLoginButton } from "./ui/GuestLoginButton";
 export { LoginForm } from "./ui/LoginForm";

--- a/src/features/auth/model/useSessionExpiryRedirect.ts
+++ b/src/features/auth/model/useSessionExpiryRedirect.ts
@@ -1,0 +1,15 @@
+import { router } from "expo-router";
+import { useEffect } from "react";
+
+import { setOnSessionExpired } from "~/shared/api/client";
+
+export function useSessionExpiryRedirect(): void {
+  useEffect(() => {
+    setOnSessionExpired(() => {
+      router.replace("/login");
+    });
+    return () => {
+      setOnSessionExpired(null);
+    };
+  }, []);
+}

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,8 +1,30 @@
-import axios from "axios";
+import axios, { AxiosError, type InternalAxiosRequestConfig } from "axios";
 
 import { env } from "~/shared/config/env";
 
-import { getAccessToken } from "./tokenStorage";
+import {
+  clearTokens,
+  getAccessToken,
+  getRefreshToken,
+  setAccessToken,
+} from "./tokenStorage";
+
+const REFRESH_ENDPOINT = "/auth/refresh-token";
+const AUTH_PUBLIC_ENDPOINTS = [
+  "/auth/signIn",
+  "/auth/signUp",
+  "/auth/signIn/kakao",
+];
+
+interface RetriableConfig extends InternalAxiosRequestConfig {
+  _retry?: boolean;
+}
+
+let onSessionExpired: (() => void) | null = null;
+
+export function setOnSessionExpired(callback: (() => void) | null): void {
+  onSessionExpired = callback;
+}
 
 export const apiClient = axios.create({
   baseURL: `${env.apiBase}/${env.teamId}`,
@@ -16,3 +38,59 @@ apiClient.interceptors.request.use(async (config) => {
   }
   return config;
 });
+
+let refreshPromise: Promise<string> | null = null;
+
+async function performRefresh(): Promise<string> {
+  const refreshToken = await getRefreshToken();
+  if (!refreshToken) throw new Error("No refresh token available");
+
+  const response = await axios.post<{ accessToken: string }>(
+    `${env.apiBase}/${env.teamId}${REFRESH_ENDPOINT}`,
+    { refreshToken },
+    { timeout: 10000 },
+  );
+  await setAccessToken(response.data.accessToken);
+  return response.data.accessToken;
+}
+
+function getOrStartRefresh(): Promise<string> {
+  if (refreshPromise) return refreshPromise;
+  refreshPromise = performRefresh().finally(() => {
+    refreshPromise = null;
+  });
+  return refreshPromise;
+}
+
+function isPublicAuthEndpoint(url: string | undefined): boolean {
+  if (!url) return false;
+  if (url.includes(REFRESH_ENDPOINT)) return true;
+  return AUTH_PUBLIC_ENDPOINTS.some((endpoint) => url.includes(endpoint));
+}
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    const config = error.config as RetriableConfig | undefined;
+    const status = error.response?.status;
+
+    if (!config || status !== 401 || config._retry) {
+      return Promise.reject(error);
+    }
+    if (isPublicAuthEndpoint(config.url)) {
+      return Promise.reject(error);
+    }
+
+    config._retry = true;
+
+    try {
+      const newAccessToken = await getOrStartRefresh();
+      config.headers.Authorization = `Bearer ${newAccessToken}`;
+      return apiClient(config);
+    } catch (refreshError) {
+      await clearTokens();
+      onSessionExpired?.();
+      return Promise.reject(refreshError);
+    }
+  },
+);


### PR DESCRIPTION
## ✏️ 작업 내용

- `apiClient.interceptors.response.use(...)` 응답 인터셉터 추가 (`src/shared/api/client.ts`)
  - 401 응답 시 `POST /auth/refresh-token` 으로 access token 갱신 → 원본 요청 재시도
  - **Single-flight refresh**: 동시 다발 401 요청이 있어도 refresh는 한 번만 호출 (race condition 방지)
  - `_retry` 플래그로 무한 재시도 방지
  - `/auth/signIn`, `/auth/signUp`, `/auth/signIn/kakao`, `/auth/refresh-token` 자체는 갱신 시도 제외
  - refresh 실패 시 `clearTokens()` + 등록된 세션 만료 콜백 호출
- `setOnSessionExpired(callback)` 노출 — 인터셉터 ↔ 라우터 결합도 분리
- `useSessionExpiryRedirect` 훅 추가 (`src/features/auth/model/`) — 마운트 시 `router.replace('/login')` 콜백 등록
- `_layout.tsx`의 `RootLayout`에서 위 훅 호출하여 와이어업

## 🗨️ 논의 사항 (참고 사항)

- 백엔드 `POST /{teamId}/auth/refresh-token`은 새 access token만 반환하고 refresh token은 갱신하지 않음 → refresh token이 만료된 시점에서만 로그인 화면으로 이동
- 인터셉터가 직접 `router.replace`를 호출하지 않고 콜백 등록 방식으로 분리한 이유: 인터셉터(shared 레이어)가 라우팅(app 레이어)에 의존하지 않도록 하기 위함
- single-flight 구현은 `refreshPromise`를 모듈 변수로 두고 `.finally()`로 자가 클리어 — 여러 awaiter가 같은 promise를 공유하므로 안전

## 기대효과

- access token 만료 시 사용자가 인지하지 못하는 사이 자동 갱신되어 요청이 자연스럽게 이어진다
- refresh token도 만료된 경우에만 로그인 화면으로 자동 이동
- 모바일에서 BFF 없이도 웹과 동등한 토큰 자동 갱신 UX 제공

Closes #67
