### PR TITLE
refactor: 검색 페이지 레이어 분리 및 regex 호이스팅 (#69)

### DIFF
--- a/src/features/epigram-search/index.ts
+++ b/src/features/epigram-search/index.ts
@@ -1,4 +1,6 @@
 export { useRecentSearches } from "./model/useRecentSearches";
 export { useSearch } from "./model/useSearch";
 export { SearchBar } from "./ui/SearchBar";
+export { RecentSearchList } from "./ui/RecentSearchList";
 export { SearchResultItem } from "./ui/SearchResultItem";
+export { SearchResults } from "./ui/SearchResults";

--- a/src/features/epigram-search/lib/highlight.ts
+++ b/src/features/epigram-search/lib/highlight.ts
@@ -1,0 +1,8 @@
+const REGEX_ESCAPE_PATTERN = /[.*+?^${}()|[\]\\]/g;
+
+export function buildHighlightRegex(keyword: string): RegExp | null {
+  const trimmed = keyword.trim();
+  if (!trimmed) return null;
+  const escaped = trimmed.replace(REGEX_ESCAPE_PATTERN, "\\$&");
+  return new RegExp(`(${escaped})`, "i");
+}

--- a/src/features/epigram-search/model/useRecentSearches.ts
+++ b/src/features/epigram-search/model/useRecentSearches.ts
@@ -33,18 +33,14 @@ export function useRecentSearches(): UseRecentSearchesResult {
         const parsed = parseStored(raw);
         if (parsed) setRecentSearches(parsed);
       })
-      .catch(() => {
-        // 읽기 실패는 빈 배열로 폴백
-      });
+      .catch(() => {});
     return () => {
       cancelled = true;
     };
   }, []);
 
   const persist = useCallback((next: string[]): void => {
-    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next)).catch(() => {
-      // 저장 실패는 다음 기회로 미룸
-    });
+    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next)).catch(() => {});
   }, []);
 
   const addRecentSearch = useCallback(

--- a/src/features/epigram-search/ui/RecentSearchList.tsx
+++ b/src/features/epigram-search/ui/RecentSearchList.tsx
@@ -1,0 +1,67 @@
+import { type ReactElement } from "react";
+import { Pressable, Text, View } from "react-native";
+
+interface RecentSearchListProps {
+  recentSearches: string[];
+  onSelect: (keyword: string) => void;
+  onClearAll: () => void;
+}
+
+interface RecentSearchChipProps {
+  keyword: string;
+  onSelect: (keyword: string) => void;
+}
+
+function RecentSearchChip({
+  keyword,
+  onSelect,
+}: RecentSearchChipProps): ReactElement {
+  function handlePress(): void {
+    onSelect(keyword);
+  }
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      accessibilityRole="button"
+      accessibilityLabel={`최근 검색어 ${keyword}로 검색`}
+      className="rounded-full bg-blue-200 px-3 py-1.5 active:bg-blue-300"
+    >
+      <Text className="font-sans text-sm text-black-600">{keyword}</Text>
+    </Pressable>
+  );
+}
+
+export function RecentSearchList({
+  recentSearches,
+  onSelect,
+  onClearAll,
+}: RecentSearchListProps): ReactElement | null {
+  if (recentSearches.length === 0) return null;
+
+  return (
+    <View className="gap-3">
+      <View className="flex-row items-center justify-between">
+        <Text className="font-sans text-sm font-semibold text-black-600">
+          최근 검색어
+        </Text>
+        <Pressable
+          onPress={onClearAll}
+          accessibilityRole="button"
+          className="active:opacity-70"
+        >
+          <Text className="font-sans text-xs text-blue-400">모두 지우기</Text>
+        </Pressable>
+      </View>
+      <View className="flex-row flex-wrap gap-2">
+        {recentSearches.map((keyword) => (
+          <RecentSearchChip
+            key={keyword}
+            keyword={keyword}
+            onSelect={onSelect}
+          />
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/src/features/epigram-search/ui/SearchBar.tsx
+++ b/src/features/epigram-search/ui/SearchBar.tsx
@@ -1,102 +1,43 @@
 import { Search } from "lucide-react-native";
 import { type ReactElement } from "react";
-import { Pressable, Text, TextInput, View } from "react-native";
+import { Pressable, TextInput, View } from "react-native";
 
 interface SearchBarProps {
   inputValue: string;
-  recentSearches: string[];
   onInputChange: (value: string) => void;
   onSearch: (keyword: string) => void;
-  onClearAllRecent: () => void;
-}
-
-interface RecentSearchChipProps {
-  keyword: string;
-  onSelect: (keyword: string) => void;
-}
-
-function RecentSearchChip({
-  keyword,
-  onSelect,
-}: RecentSearchChipProps): ReactElement {
-  function handlePress(): void {
-    onSelect(keyword);
-  }
-
-  return (
-    <Pressable
-      onPress={handlePress}
-      accessibilityRole="button"
-      accessibilityLabel={`최근 검색어 ${keyword}로 검색`}
-      className="rounded-full bg-blue-200 px-3 py-1.5 active:bg-blue-300"
-    >
-      <Text className="font-sans text-sm text-black-600">{keyword}</Text>
-    </Pressable>
-  );
 }
 
 export function SearchBar({
   inputValue,
-  recentSearches,
   onInputChange,
   onSearch,
-  onClearAllRecent,
 }: SearchBarProps): ReactElement {
   function handleSubmit(): void {
     onSearch(inputValue);
   }
 
   return (
-    <View className="w-full gap-6">
-      <View className="flex-row items-center border-b-2 border-blue-300 pb-2">
-        <TextInput
-          value={inputValue}
-          onChangeText={onInputChange}
-          onSubmitEditing={handleSubmit}
-          returnKeyType="search"
-          placeholder="검색어를 입력하세요"
-          placeholderTextColor="#abb8ce"
-          autoCorrect={false}
-          autoCapitalize="none"
-          className="h-10 flex-1 font-sans text-base text-black-900"
-        />
-        <Pressable
-          onPress={handleSubmit}
-          accessibilityRole="button"
-          accessibilityLabel="검색"
-          className="ml-2 h-10 w-10 items-center justify-center active:opacity-70"
-        >
-          <Search size={20} color="#abb8ce" />
-        </Pressable>
-      </View>
-
-      {recentSearches.length > 0 && (
-        <View className="gap-3">
-          <View className="flex-row items-center justify-between">
-            <Text className="font-sans text-sm font-semibold text-black-600">
-              최근 검색어
-            </Text>
-            <Pressable
-              onPress={onClearAllRecent}
-              accessibilityRole="button"
-              className="active:opacity-70"
-            >
-              <Text className="font-sans text-xs text-blue-400">
-                모두 지우기
-              </Text>
-            </Pressable>
-          </View>
-          <View className="flex-row flex-wrap gap-2">
-            {recentSearches.map((keyword) => (
-              <RecentSearchChip
-                key={keyword}
-                keyword={keyword}
-                onSelect={onSearch}
-              />
-            ))}
-          </View>
-        </View>
-      )}
+    <View className="flex-row items-center border-b-2 border-blue-300 pb-2">
+      <TextInput
+        value={inputValue}
+        onChangeText={onInputChange}
+        onSubmitEditing={handleSubmit}
+        returnKeyType="search"
+        placeholder="검색어를 입력하세요"
+        placeholderTextColor="#abb8ce"
+        autoCorrect={false}
+        autoCapitalize="none"
+        className="h-10 flex-1 font-sans text-base text-black-900"
+      />
+      <Pressable
+        onPress={handleSubmit}
+        accessibilityRole="button"
+        accessibilityLabel="검색"
+        className="ml-2 h-10 w-10 items-center justify-center active:opacity-70"
+      >
+        <Search size={20} color="#abb8ce" />
+      </Pressable>
     </View>
   );
 }

--- a/src/features/epigram-search/ui/SearchResultItem.tsx
+++ b/src/features/epigram-search/ui/SearchResultItem.tsx
@@ -1,12 +1,12 @@
 import { router } from "expo-router";
-import { memo, type ReactElement, useMemo } from "react";
+import { memo, type ReactElement } from "react";
 import { Pressable, Text, View } from "react-native";
 
 import type { Epigram } from "~/entities/epigram";
 
 interface SearchResultItemProps {
   epigram: Epigram;
-  keyword: string;
+  highlightRegex: RegExp | null;
 }
 
 interface HighlightedSegment {
@@ -15,7 +15,6 @@ interface HighlightedSegment {
 }
 
 function buildSegments(text: string, regex: RegExp): HighlightedSegment[] {
-  // split alternates: even indices are plain, odd indices are matched groups
   return text.split(regex).map((part, index) => ({
     text: part,
     isMatch: index % 2 === 1,
@@ -24,23 +23,17 @@ function buildSegments(text: string, regex: RegExp): HighlightedSegment[] {
 
 interface HighlightedTextProps {
   text: string;
-  keyword: string;
+  regex: RegExp | null;
   className: string;
   highlightClassName: string;
 }
 
 function HighlightedText({
   text,
-  keyword,
+  regex,
   className,
   highlightClassName,
 }: HighlightedTextProps): ReactElement {
-  const regex = useMemo(() => {
-    if (!keyword.trim()) return null;
-    const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    return new RegExp(`(${escaped})`, "i");
-  }, [keyword]);
-
   if (!regex) return <Text className={className}>{text}</Text>;
 
   return (
@@ -60,10 +53,10 @@ function HighlightedText({
 
 interface TagListProps {
   tags: Epigram["tags"];
-  keyword: string;
+  highlightRegex: RegExp | null;
 }
 
-function TagList({ tags, keyword }: TagListProps): ReactElement | null {
+function TagList({ tags, highlightRegex }: TagListProps): ReactElement | null {
   if (tags.length === 0) return null;
 
   return (
@@ -76,7 +69,7 @@ function TagList({ tags, keyword }: TagListProps): ReactElement | null {
           #
           <HighlightedText
             text={tag.name}
-            keyword={keyword}
+            regex={highlightRegex}
             className="font-sans text-sm text-blue-500"
             highlightClassName="font-semibold text-illust-blue"
           />
@@ -88,7 +81,7 @@ function TagList({ tags, keyword }: TagListProps): ReactElement | null {
 
 function SearchResultItemBase({
   epigram,
-  keyword,
+  highlightRegex,
 }: SearchResultItemProps): ReactElement {
   const authorLabel = epigram.referenceTitle
     ? `${epigram.author} 《${epigram.referenceTitle}》`
@@ -108,7 +101,7 @@ function SearchResultItemBase({
         <View className="gap-3">
           <HighlightedText
             text={epigram.content}
-            keyword={keyword}
+            regex={highlightRegex}
             className="font-serif text-base text-black-700"
             highlightClassName="font-semibold text-illust-blue"
           />
@@ -117,7 +110,7 @@ function SearchResultItemBase({
           </Text>
         </View>
 
-        <TagList tags={epigram.tags} keyword={keyword} />
+        <TagList tags={epigram.tags} highlightRegex={highlightRegex} />
       </View>
     </Pressable>
   );

--- a/src/features/epigram-search/ui/SearchResults.tsx
+++ b/src/features/epigram-search/ui/SearchResults.tsx
@@ -1,0 +1,154 @@
+import { SearchX } from "lucide-react-native";
+import { useCallback, useMemo, type ReactElement } from "react";
+import {
+  ActivityIndicator,
+  FlatList,
+  Text,
+  View,
+  type ListRenderItem,
+} from "react-native";
+
+import { useSearchEpigrams, type Epigram } from "~/entities/epigram";
+
+import { buildHighlightRegex } from "../lib/highlight";
+
+import { SearchResultItem } from "./SearchResultItem";
+
+const SEARCH_LIMIT = 10;
+
+interface SearchResultsProps {
+  keyword: string;
+}
+
+function SearchResultSkeletonItem(): ReactElement {
+  return (
+    <View className="border-b border-line-100 py-5">
+      <View className="gap-2.5">
+        <View className="h-3.5 w-4/5 rounded-md bg-blue-200" />
+        <View className="h-3.5 w-1/2 rounded-md bg-blue-200" />
+        <View className="flex-row gap-2 pt-1">
+          <View className="h-5 w-14 rounded-full bg-blue-200" />
+          <View className="h-5 w-20 rounded-full bg-blue-200" />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function SearchResultSkeleton(): ReactElement {
+  return (
+    <View>
+      {Array.from({ length: 4 }).map((_, i) => (
+        <SearchResultSkeletonItem key={i} />
+      ))}
+    </View>
+  );
+}
+
+interface SearchNoResultsProps {
+  keyword: string;
+}
+
+function SearchNoResults({ keyword }: SearchNoResultsProps): ReactElement {
+  return (
+    <View className="items-center gap-5 py-24">
+      <View className="h-16 w-16 items-center justify-center rounded-full bg-blue-200">
+        <SearchX size={28} color="#52698e" strokeWidth={1.5} />
+      </View>
+      <View className="items-center gap-1.5 px-screen-x">
+        <Text className="text-center font-sans text-sm text-black-600">
+          <Text className="font-semibold text-blue-700">
+            &ldquo;{keyword}&rdquo;
+          </Text>
+          에 대한 결과가 없어요
+        </Text>
+        <Text className="text-center font-sans text-xs text-black-300">
+          철자를 확인하거나 다른 검색어를 입력해 보세요
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+export function SearchResults({ keyword }: SearchResultsProps): ReactElement {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
+    useSearchEpigrams({ keyword, limit: SEARCH_LIMIT });
+
+  const epigrams = useMemo(
+    () => data?.pages.flatMap((page) => page.list) ?? [],
+    [data?.pages],
+  );
+
+  const highlightRegex = useMemo(() => buildHighlightRegex(keyword), [keyword]);
+
+  const handleEndReached = useCallback((): void => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const renderItem: ListRenderItem<Epigram> = useCallback(
+    ({ item }) => (
+      <SearchResultItem epigram={item} highlightRegex={highlightRegex} />
+    ),
+    [highlightRegex],
+  );
+
+  if (isLoading) return <SearchResultSkeleton />;
+  if (epigrams.length === 0) return <SearchNoResults keyword={keyword} />;
+
+  return (
+    <FlatList
+      data={epigrams}
+      keyExtractor={(item) => String(item.id)}
+      renderItem={renderItem}
+      onEndReached={handleEndReached}
+      onEndReachedThreshold={0.5}
+      ListHeaderComponent={
+        <Text className="mb-4 font-sans text-xs text-black-300">
+          검색 결과{" "}
+          <Text className="font-semibold text-blue-700">
+            {epigrams.length}
+            {hasNextPage ? "+" : ""}
+          </Text>
+        </Text>
+      }
+      ListFooterComponent={
+        <SearchResultsFooter
+          isFetchingNextPage={isFetchingNextPage}
+          hasNextPage={hasNextPage}
+          loadedCount={epigrams.length}
+        />
+      }
+      keyboardShouldPersistTaps="handled"
+    />
+  );
+}
+
+interface SearchResultsFooterProps {
+  isFetchingNextPage: boolean;
+  hasNextPage: boolean;
+  loadedCount: number;
+}
+
+function SearchResultsFooter({
+  isFetchingNextPage,
+  hasNextPage,
+  loadedCount,
+}: SearchResultsFooterProps): ReactElement | null {
+  if (isFetchingNextPage) {
+    return (
+      <View className="items-center py-8">
+        <ActivityIndicator color="#abb8ce" />
+      </View>
+    );
+  }
+  if (!hasNextPage && loadedCount > 0) {
+    return (
+      <View className="items-center py-8">
+        <Text className="font-sans text-xs text-black-300">
+          모든 결과를 불러왔습니다
+        </Text>
+      </View>
+    );
+  }
+  return null;
+}

--- a/src/views/search/ui/SearchScreen.tsx
+++ b/src/views/search/ui/SearchScreen.tsx
@@ -1,73 +1,13 @@
-import { SearchX } from "lucide-react-native";
-import { useCallback, useMemo, type ReactElement } from "react";
-import {
-  ActivityIndicator,
-  FlatList,
-  Keyboard,
-  Text,
-  View,
-  type ListRenderItem,
-} from "react-native";
+import { useCallback, type ReactElement } from "react";
+import { Keyboard, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-import { useSearchEpigrams, type Epigram } from "~/entities/epigram";
 import {
+  RecentSearchList,
   SearchBar,
-  SearchResultItem,
+  SearchResults,
   useSearch,
 } from "~/features/epigram-search";
-
-const SEARCH_LIMIT = 10;
-
-function SearchResultSkeletonItem(): ReactElement {
-  return (
-    <View className="border-b border-line-100 py-5">
-      <View className="gap-2.5">
-        <View className="h-3.5 w-4/5 rounded-md bg-blue-200" />
-        <View className="h-3.5 w-1/2 rounded-md bg-blue-200" />
-        <View className="flex-row gap-2 pt-1">
-          <View className="h-5 w-14 rounded-full bg-blue-200" />
-          <View className="h-5 w-20 rounded-full bg-blue-200" />
-        </View>
-      </View>
-    </View>
-  );
-}
-
-function SearchResultSkeleton(): ReactElement {
-  return (
-    <View>
-      {Array.from({ length: 4 }).map((_, i) => (
-        <SearchResultSkeletonItem key={i} />
-      ))}
-    </View>
-  );
-}
-
-interface SearchNoResultsProps {
-  keyword: string;
-}
-
-function SearchNoResults({ keyword }: SearchNoResultsProps): ReactElement {
-  return (
-    <View className="items-center gap-5 py-24">
-      <View className="h-16 w-16 items-center justify-center rounded-full bg-blue-200">
-        <SearchX size={28} color="#52698e" strokeWidth={1.5} />
-      </View>
-      <View className="items-center gap-1.5 px-screen-x">
-        <Text className="text-center font-sans text-sm text-black-600">
-          <Text className="font-semibold text-blue-700">
-            &ldquo;{keyword}&rdquo;
-          </Text>
-          에 대한 결과가 없어요
-        </Text>
-        <Text className="text-center font-sans text-xs text-black-300">
-          철자를 확인하거나 다른 검색어를 입력해 보세요
-        </Text>
-      </View>
-    </View>
-  );
-}
 
 function InitialState(): ReactElement {
   return (
@@ -87,78 +27,6 @@ function InitialState(): ReactElement {
         </Text>
       </View>
     </View>
-  );
-}
-
-interface SearchResultsProps {
-  keyword: string;
-}
-
-function SearchResults({ keyword }: SearchResultsProps): ReactElement {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
-    useSearchEpigrams({ keyword, limit: SEARCH_LIMIT });
-
-  const epigrams = useMemo(
-    () => data?.pages.flatMap((page) => page.list) ?? [],
-    [data?.pages],
-  );
-
-  const handleEndReached = useCallback((): void => {
-    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
-
-  const renderItem: ListRenderItem<Epigram> = useCallback(
-    ({ item }) => <SearchResultItem epigram={item} keyword={keyword} />,
-    [keyword],
-  );
-
-  const headerElement = useMemo(
-    () => (
-      <Text className="mb-4 font-sans text-xs text-black-300">
-        검색 결과{" "}
-        <Text className="font-semibold text-blue-700">
-          {epigrams.length}
-          {hasNextPage ? "+" : ""}
-        </Text>
-      </Text>
-    ),
-    [epigrams.length, hasNextPage],
-  );
-
-  const footerElement = useMemo(() => {
-    if (isFetchingNextPage) {
-      return (
-        <View className="items-center py-8">
-          <ActivityIndicator color="#abb8ce" />
-        </View>
-      );
-    }
-    if (!hasNextPage && epigrams.length > 0) {
-      return (
-        <View className="items-center py-8">
-          <Text className="font-sans text-xs text-black-300">
-            모든 결과를 불러왔습니다
-          </Text>
-        </View>
-      );
-    }
-    return null;
-  }, [isFetchingNextPage, hasNextPage, epigrams.length]);
-
-  if (isLoading) return <SearchResultSkeleton />;
-  if (epigrams.length === 0) return <SearchNoResults keyword={keyword} />;
-
-  return (
-    <FlatList
-      data={epigrams}
-      keyExtractor={(item) => String(item.id)}
-      renderItem={renderItem}
-      onEndReached={handleEndReached}
-      onEndReachedThreshold={0.5}
-      ListHeaderComponent={headerElement}
-      ListFooterComponent={footerElement}
-      keyboardShouldPersistTaps="handled"
-    />
   );
 }
 
@@ -182,13 +50,16 @@ export function SearchScreen(): ReactElement {
 
   return (
     <SafeAreaView className="flex-1 bg-background" edges={["top"]}>
-      <View className="px-screen-x pt-6">
+      <View className="gap-6 px-screen-x pt-6">
         <SearchBar
           inputValue={inputValue}
-          recentSearches={recentSearches}
           onInputChange={handleInputChange}
           onSearch={handleSearchAndDismiss}
-          onClearAllRecent={clearAllRecentSearches}
+        />
+        <RecentSearchList
+          recentSearches={recentSearches}
+          onSelect={handleSearchAndDismiss}
+          onClearAll={clearAllRecentSearches}
         />
       </View>
       <View className="mt-8 flex-1 px-screen-x">


### PR DESCRIPTION
## ✏️ 작업 내용

### 1. Regex 호이스팅 (효율)
- `buildHighlightRegex(keyword)` 헬퍼를 `features/epigram-search/lib/highlight.ts`로 추출
- 기존: `HighlightedText` 인스턴스마다 useMemo로 동일 regex 재생성 (10결과 × ~3 하이라이트 ≈ 30개 객체)
- 변경: `SearchResults`에서 한 번 계산 → `regex` prop으로 `SearchResultItem` → `HighlightedText`까지 전달
- `SearchResultItem`/`HighlightedText`/`TagList`의 `keyword` prop을 `highlightRegex: RegExp | null`로 교체

### 2. 레이어 분리 (FSD)
- 데이터 페칭 + FlatList 컴포지션은 feature 책임 → `views/search/ui/SearchScreen.tsx` → `features/epigram-search/ui/SearchResults.tsx`로 이동
- `SearchResultSkeleton`·`SearchResultSkeletonItem`·`SearchNoResults`도 결과 렌더링과 묶여있어 함께 이동
- `SearchScreen`은 `SearchBar` + `RecentSearchList` + `SearchResults`/`InitialState` 컴포지션만 담당 (200줄 → 75줄)

### 3. SRP — `RecentSearchList` 분리
- `SearchBar`가 입력 row + 최근 검색 chip list 두 책임 (5 props) → 입력만 담당 (3 props)
- `RecentSearchList`를 `features/epigram-search/ui/RecentSearchList.tsx`로 분리 (3 props)
- `RecentSearchChip`은 `RecentSearchList` 내부 헬퍼로 함께 이동

### 4. 불필요 주석 제거 (헌법: 명백한 코드 설명 금지)
- `useRecentSearches.ts`: catch 빈 블록의 폴백 설명 주석 2개 제거
- `SearchResultItem.tsx`: `split alternates...` WHAT 설명 주석 제거

### 5. 조기 메모이제이션 제거
- `SearchScreen`의 `headerElement`·`footerElement` `useMemo` 제거
- 헤더는 인라인 element, 푸터는 `SearchResultsFooter` 서브 컴포넌트로 분리해 props로 상태 전달

## 🗨️ 논의 사항 (참고 사항)

- 비즈니스 로직 변경 없음 — 사용자에게 보이는 동작은 동일
- `SearchResults.tsx` 내부에서 `SearchResultsFooter`를 별도 함수로 분리한 이유: `useMemo` 없이도 같은 의도(상태에 따라 다른 footer 렌더)를 헌법(단일 책임)에 맞게 표현
- `SearchScreen.tsx`는 view 레이어 답게 페이지 컴포지션만 남음 — `InitialState`만 view-level UI라 inline 유지
- `EmptyState` / `Skeleton` 공통 추출은 다른 위젯과의 중복이 있지만 기존 기술 부채 영역이라 이번 PR 스코프 외

## 기대효과

- 키워드 변경 시 동일 regex 객체 ~30개 → 1개 생성 (페이지당 ~29회 regex 컴파일 절감)
- FSD 레이어 책임 명확화: view = 컴포지션, feature = 검색 동작/데이터/렌더
- `SearchBar` SRP 회복으로 재사용성·테스트 용이성 향상

Closes #69
