### PR TITLE
feat: 에피그램 작성·수정 model 레이어 추가

### DIFF
--- a/src/entities/epigram/api/updateEpigram.ts
+++ b/src/entities/epigram/api/updateEpigram.ts
@@ -1,0 +1,22 @@
+import { apiClient } from "~/shared/api/client";
+
+import { epigramSchema, type Epigram } from "../model/schema";
+
+export interface UpdateEpigramRequest {
+  content?: string;
+  author?: string;
+  referenceTitle?: string;
+  referenceUrl?: string;
+  tags?: string[];
+}
+
+export async function updateEpigram(
+  epigramId: number,
+  data: UpdateEpigramRequest,
+): Promise<Epigram> {
+  const response = await apiClient.patch<unknown>(
+    `/epigrams/${epigramId}`,
+    data,
+  );
+  return epigramSchema.parse(response.data);
+}

--- a/src/entities/epigram/index.ts
+++ b/src/entities/epigram/index.ts
@@ -13,6 +13,8 @@ export type {
 
 export { createEpigram } from "./api/createEpigram";
 export type { CreateEpigramRequest } from "./api/createEpigram";
+export { updateEpigram } from "./api/updateEpigram";
+export type { UpdateEpigramRequest } from "./api/updateEpigram";
 export { epigramKeys } from "./api/keys";
 export { useEpigramDetail } from "./api/useEpigramDetail";
 export { useEpigrams } from "./api/useEpigrams";

--- a/src/features/epigram-create/index.ts
+++ b/src/features/epigram-create/index.ts
@@ -1,0 +1,3 @@
+export { AUTHOR_TYPE, epigramCreateFormSchema } from "./model/schema";
+export type { AuthorType, EpigramCreateFormValues } from "./model/schema";
+export { useEpigramCreate } from "./model/useEpigramCreate";

--- a/src/features/epigram-create/model/schema.ts
+++ b/src/features/epigram-create/model/schema.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+export const AUTHOR_TYPE = {
+  DIRECT: "direct",
+  UNKNOWN: "unknown",
+  SELF: "self",
+} as const;
+
+export type AuthorType = (typeof AUTHOR_TYPE)[keyof typeof AUTHOR_TYPE];
+
+export const epigramCreateFormSchema = z
+  .object({
+    content: z
+      .string()
+      .min(1, "내용을 입력해주세요.")
+      .max(500, "내용은 500자 이내로 입력해주세요."),
+    authorType: z.enum([
+      AUTHOR_TYPE.DIRECT,
+      AUTHOR_TYPE.UNKNOWN,
+      AUTHOR_TYPE.SELF,
+    ]),
+    authorName: z
+      .string()
+      .max(30, "저자명은 30자 이내로 입력해주세요.")
+      .optional(),
+    referenceTitle: z
+      .string()
+      .max(100, "출처 제목은 100자 이내로 입력해주세요.")
+      .optional(),
+    referenceUrl: z
+      .string()
+      .optional()
+      .refine(
+        (val) => !val || /^https?:\/\/.+/.test(val),
+        "올바른 URL 형식을 입력해주세요. (ex. https://www.website.com)",
+      ),
+    tags: z
+      .array(z.string().min(1).max(10, "태그는 10자 이내로 입력해주세요."))
+      .max(3, "태그는 최대 3개까지 추가할 수 있습니다."),
+  })
+  .superRefine((data, ctx) => {
+    if (data.authorType === AUTHOR_TYPE.DIRECT && !data.authorName?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "저자 이름을 입력해주세요.",
+        path: ["authorName"],
+      });
+    }
+  });
+
+export type EpigramCreateFormValues = z.infer<typeof epigramCreateFormSchema>;

--- a/src/features/epigram-create/model/useEpigramCreate.ts
+++ b/src/features/epigram-create/model/useEpigramCreate.ts
@@ -1,0 +1,74 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { router } from "expo-router";
+
+import { createEpigram, epigramKeys } from "~/entities/epigram";
+import { useTagInput } from "~/shared/hooks/useTagInput";
+
+import { AUTHOR_TYPE, type EpigramCreateFormValues } from "./schema";
+
+interface UseEpigramCreateReturn {
+  tagInput: string;
+  isSubmitting: boolean;
+  hasError: boolean;
+  handleTagInputChange: (value: string) => void;
+  handleAddTag: (
+    currentTags: string[],
+    onChange: (tags: string[]) => void,
+  ) => void;
+  handleRemoveTag: (
+    tag: string,
+    currentTags: string[],
+    onChange: (tags: string[]) => void,
+  ) => void;
+  submit: (values: EpigramCreateFormValues) => void;
+}
+
+function resolveAuthor(
+  values: EpigramCreateFormValues,
+  userNickname: string | undefined,
+): string {
+  if (values.authorType === AUTHOR_TYPE.UNKNOWN) return "알 수 없음";
+  if (values.authorType === AUTHOR_TYPE.SELF) return userNickname ?? "본인";
+  return values.authorName ?? "";
+}
+
+export function useEpigramCreate(
+  userNickname?: string,
+): UseEpigramCreateReturn {
+  const queryClient = useQueryClient();
+  const { tagInput, handleTagInputChange, handleAddTag, handleRemoveTag } =
+    useTagInput();
+
+  const {
+    mutate,
+    isPending: isSubmitting,
+    isError: hasError,
+  } = useMutation({
+    mutationFn: (values: EpigramCreateFormValues) =>
+      createEpigram({
+        content: values.content,
+        author: resolveAuthor(values, userNickname),
+        referenceTitle: values.referenceTitle?.trim() || undefined,
+        referenceUrl: values.referenceUrl?.trim() || undefined,
+        tags: values.tags,
+      }),
+    onSuccess: (epigram) => {
+      queryClient.invalidateQueries({ queryKey: epigramKeys.all });
+      router.replace(`/epigrams/${epigram.id}`);
+    },
+  });
+
+  function submit(values: EpigramCreateFormValues): void {
+    mutate(values);
+  }
+
+  return {
+    tagInput,
+    isSubmitting,
+    hasError,
+    handleTagInputChange,
+    handleAddTag,
+    handleRemoveTag,
+    submit,
+  };
+}

--- a/src/features/epigram-edit/index.ts
+++ b/src/features/epigram-edit/index.ts
@@ -1,0 +1,1 @@
+export { useEpigramEdit } from "./model/useEpigramEdit";

--- a/src/features/epigram-edit/model/useEpigramEdit.ts
+++ b/src/features/epigram-edit/model/useEpigramEdit.ts
@@ -1,0 +1,85 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { router } from "expo-router";
+
+import { epigramKeys, updateEpigram } from "~/entities/epigram";
+import {
+  AUTHOR_TYPE,
+  type EpigramCreateFormValues,
+} from "~/features/epigram-create";
+import { useTagInput } from "~/shared/hooks/useTagInput";
+
+interface UseEpigramEditReturn {
+  tagInput: string;
+  isSubmitting: boolean;
+  hasError: boolean;
+  handleTagInputChange: (value: string) => void;
+  handleAddTag: (
+    currentTags: string[],
+    onChange: (tags: string[]) => void,
+  ) => void;
+  handleRemoveTag: (
+    tag: string,
+    currentTags: string[],
+    onChange: (tags: string[]) => void,
+  ) => void;
+  handleCancel: () => void;
+  submit: (values: EpigramCreateFormValues) => void;
+}
+
+function resolveAuthor(values: EpigramCreateFormValues): string {
+  if (values.authorType === AUTHOR_TYPE.UNKNOWN) return "알 수 없음";
+  if (values.authorType === AUTHOR_TYPE.SELF)
+    return values.authorName ?? "본인";
+  return values.authorName ?? "";
+}
+
+export function useEpigramEdit(epigramId: number): UseEpigramEditReturn {
+  const queryClient = useQueryClient();
+  const { tagInput, handleTagInputChange, handleAddTag, handleRemoveTag } =
+    useTagInput();
+
+  const {
+    mutate,
+    isPending: isSubmitting,
+    isError: hasError,
+  } = useMutation({
+    mutationFn: (values: EpigramCreateFormValues) =>
+      updateEpigram(epigramId, {
+        content: values.content,
+        author: resolveAuthor(values),
+        referenceTitle: values.referenceTitle?.trim() || undefined,
+        referenceUrl: values.referenceUrl?.trim() || undefined,
+        tags: values.tags,
+      }),
+    onSuccess: (epigram) => {
+      queryClient.invalidateQueries({ queryKey: epigramKeys.all });
+      queryClient.invalidateQueries({
+        queryKey: epigramKeys.detail(epigramId),
+      });
+      router.replace(`/epigrams/${epigram.id}`);
+    },
+  });
+
+  function handleCancel(): void {
+    if (router.canGoBack()) {
+      router.back();
+      return;
+    }
+    router.replace(`/epigrams/${epigramId}`);
+  }
+
+  function submit(values: EpigramCreateFormValues): void {
+    mutate(values);
+  }
+
+  return {
+    tagInput,
+    isSubmitting,
+    hasError,
+    handleTagInputChange,
+    handleAddTag,
+    handleRemoveTag,
+    handleCancel,
+    submit,
+  };
+}

--- a/src/shared/hooks/useTagInput.ts
+++ b/src/shared/hooks/useTagInput.ts
@@ -1,0 +1,48 @@
+import { useState } from "react";
+
+const MAX_TAG_COUNT = 3;
+const MAX_TAG_LENGTH = 10;
+
+interface UseTagInputReturn {
+  tagInput: string;
+  handleTagInputChange: (value: string) => void;
+  handleAddTag: (
+    currentTags: string[],
+    onChange: (tags: string[]) => void,
+  ) => void;
+  handleRemoveTag: (
+    tag: string,
+    currentTags: string[],
+    onChange: (tags: string[]) => void,
+  ) => void;
+}
+
+export function useTagInput(): UseTagInputReturn {
+  const [tagInput, setTagInput] = useState("");
+
+  function handleTagInputChange(value: string): void {
+    setTagInput(value.slice(0, MAX_TAG_LENGTH));
+  }
+
+  function handleAddTag(
+    currentTags: string[],
+    onChange: (tags: string[]) => void,
+  ): void {
+    const trimmed = tagInput.trim();
+    if (!trimmed) return;
+    if (currentTags.length >= MAX_TAG_COUNT) return;
+    if (currentTags.includes(trimmed)) return;
+    onChange([...currentTags, trimmed]);
+    setTagInput("");
+  }
+
+  function handleRemoveTag(
+    tag: string,
+    currentTags: string[],
+    onChange: (tags: string[]) => void,
+  ): void {
+    onChange(currentTags.filter((t) => t !== tag));
+  }
+
+  return { tagInput, handleTagInputChange, handleAddTag, handleRemoveTag };
+}


### PR DESCRIPTION
## ✏️ 작업 내용

- `entities/epigram/api/updateEpigram.ts` 추가 — `PATCH /epigrams/:id` 호출 + `epigramSchema` 런타임 검증
- `features/epigram-create` 슬라이스 신설
  - `model/schema.ts` — `epigramCreateFormSchema` (content 1–500자, authorType `direct`/`unknown`/`self`, authorName 30자, referenceTitle 100자, referenceUrl `https?` 검증, tags 최대 3개·각 10자, DIRECT일 때 authorName 필수 `superRefine`)
  - `model/useEpigramCreate.ts` — `resolveAuthor` (UNKNOWN→"알 수 없음", SELF→nickname, DIRECT→authorName), 성공 시 `epigramKeys.all` 무효화 + `router.replace('/epigrams/:id')`
- `features/epigram-edit/model/useEpigramEdit.ts` 추가 — 동일 스키마 재사용, 성공 시 `epigramKeys.all` + `epigramKeys.detail(id)` 무효화, `handleCancel`은 `router.canGoBack()` 우선
- `shared/hooks/useTagInput.ts` 추가 — `MAX_TAG_COUNT=3`, `MAX_TAG_LENGTH=10`, 중복·길이·개수 가드

## 🗨️ 논의 사항

- 웹은 작성·수정 후 `router.push`인데, 모바일은 작성/수정 화면을 스택에서 빼야 자연스러우므로 `router.replace`로 통일했습니다. 디테일에서 뒤로 갔을 때 작성 폼이 다시 나오는 걸 방지하기 위함.
- `useEpigramEdit.handleCancel`은 `canGoBack()` 분기를 추가해 딥링크 등으로 진입한 경우에도 안전하게 디테일로 떨어지도록 했습니다.
- `epigram-edit` 슬라이스가 `epigram-create` 슬라이스의 스키마/타입을 재사용합니다 (FSD 동일 레이어 cross-import). 웹과 동일한 구조이며, 완전히 동일한 폼 유효성을 강제하기 위한 의도적 결정입니다.

## 기대효과

- UI 구현 전에 비즈니스 로직·검증·캐시 무효화 정책을 한 번에 확정해, 후속 PR(폼 컴포넌트, 화면)이 model 레이어를 그대로 소비할 수 있게 됩니다.
- 작성·수정 폼이 동일한 Zod 스키마와 동일한 `useTagInput`을 공유하므로 검증 규칙이 어긋날 여지가 없습니다.

Closes #71
