### PR TITLE
refactor: 작성·수정·디테일 화면 공통 UI 추출 및 EpigramEditScreen 단순화 (#77)

### DIFF
--- a/src/features/epigram-create/index.ts
+++ b/src/features/epigram-create/index.ts
@@ -1,3 +1,7 @@
-export { AUTHOR_TYPE, epigramCreateFormSchema } from "./model/schema";
+export {
+  AUTHOR_TYPE,
+  epigramCreateFormSchema,
+  UNKNOWN_AUTHOR,
+} from "./model/schema";
 export type { AuthorType, EpigramCreateFormValues } from "./model/schema";
 export { useEpigramCreate } from "./model/useEpigramCreate";

--- a/src/features/epigram-create/model/schema.ts
+++ b/src/features/epigram-create/model/schema.ts
@@ -8,6 +8,8 @@ export const AUTHOR_TYPE = {
 
 export type AuthorType = (typeof AUTHOR_TYPE)[keyof typeof AUTHOR_TYPE];
 
+export const UNKNOWN_AUTHOR = "알 수 없음";
+
 export const epigramCreateFormSchema = z
   .object({
     content: z

--- a/src/features/epigram-create/model/useEpigramCreate.ts
+++ b/src/features/epigram-create/model/useEpigramCreate.ts
@@ -4,7 +4,11 @@ import { router } from "expo-router";
 import { createEpigram, epigramKeys } from "~/entities/epigram";
 import { useTagInput } from "~/shared/hooks/useTagInput";
 
-import { AUTHOR_TYPE, type EpigramCreateFormValues } from "./schema";
+import {
+  AUTHOR_TYPE,
+  UNKNOWN_AUTHOR,
+  type EpigramCreateFormValues,
+} from "./schema";
 
 interface UseEpigramCreateReturn {
   tagInput: string;
@@ -27,7 +31,7 @@ function resolveAuthor(
   values: EpigramCreateFormValues,
   userNickname: string | undefined,
 ): string {
-  if (values.authorType === AUTHOR_TYPE.UNKNOWN) return "알 수 없음";
+  if (values.authorType === AUTHOR_TYPE.UNKNOWN) return UNKNOWN_AUTHOR;
   if (values.authorType === AUTHOR_TYPE.SELF) return userNickname ?? "본인";
   return values.authorName ?? "";
 }

--- a/src/features/epigram-edit/index.ts
+++ b/src/features/epigram-edit/index.ts
@@ -1,1 +1,2 @@
+export { resolveDefaultValues } from "./model/resolveDefaultValues";
 export { useEpigramEdit } from "./model/useEpigramEdit";

--- a/src/features/epigram-edit/model/resolveDefaultValues.ts
+++ b/src/features/epigram-edit/model/resolveDefaultValues.ts
@@ -1,0 +1,20 @@
+import { type EpigramDetail } from "~/entities/epigram";
+import {
+  AUTHOR_TYPE,
+  UNKNOWN_AUTHOR,
+  type EpigramCreateFormValues,
+} from "~/features/epigram-create";
+
+export function resolveDefaultValues(
+  epigram: EpigramDetail,
+): EpigramCreateFormValues {
+  const isUnknown = epigram.author === UNKNOWN_AUTHOR;
+  return {
+    content: epigram.content,
+    authorType: isUnknown ? AUTHOR_TYPE.UNKNOWN : AUTHOR_TYPE.DIRECT,
+    authorName: isUnknown ? "" : epigram.author,
+    referenceTitle: epigram.referenceTitle ?? "",
+    referenceUrl: epigram.referenceUrl ?? "",
+    tags: epigram.tags.map((tag) => tag.name),
+  };
+}

--- a/src/features/epigram-edit/model/useEpigramEdit.ts
+++ b/src/features/epigram-edit/model/useEpigramEdit.ts
@@ -4,6 +4,7 @@ import { router } from "expo-router";
 import { epigramKeys, updateEpigram } from "~/entities/epigram";
 import {
   AUTHOR_TYPE,
+  UNKNOWN_AUTHOR,
   type EpigramCreateFormValues,
 } from "~/features/epigram-create";
 import { useTagInput } from "~/shared/hooks/useTagInput";
@@ -27,7 +28,7 @@ interface UseEpigramEditReturn {
 }
 
 function resolveAuthor(values: EpigramCreateFormValues): string {
-  if (values.authorType === AUTHOR_TYPE.UNKNOWN) return "알 수 없음";
+  if (values.authorType === AUTHOR_TYPE.UNKNOWN) return UNKNOWN_AUTHOR;
   if (values.authorType === AUTHOR_TYPE.SELF)
     return values.authorName ?? "본인";
   return values.authorName ?? "";

--- a/src/shared/ui/ErrorState.tsx
+++ b/src/shared/ui/ErrorState.tsx
@@ -1,0 +1,14 @@
+import { type ReactElement } from "react";
+import { Text, View } from "react-native";
+
+interface ErrorStateProps {
+  message: string;
+}
+
+export function ErrorState({ message }: ErrorStateProps): ReactElement {
+  return (
+    <View className="flex-1 items-center justify-center px-screen-x">
+      <Text className="font-sans text-base text-error">{message}</Text>
+    </View>
+  );
+}

--- a/src/shared/ui/LoadingState.tsx
+++ b/src/shared/ui/LoadingState.tsx
@@ -1,0 +1,10 @@
+import { type ReactElement } from "react";
+import { ActivityIndicator, View } from "react-native";
+
+export function LoadingState(): ReactElement {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <ActivityIndicator color="#6a82a9" />
+    </View>
+  );
+}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,5 +1,7 @@
 export { Button } from "./Button";
 export type { ButtonProps } from "./Button";
+export { ErrorState } from "./ErrorState";
 export { Input } from "./Input";
 export type { InputProps } from "./Input";
+export { LoadingState } from "./LoadingState";
 export { PrivacyToggle } from "./PrivacyToggle";

--- a/src/views/add-epigram/ui/AddEpigramScreen.tsx
+++ b/src/views/add-epigram/ui/AddEpigramScreen.tsx
@@ -1,10 +1,8 @@
-import { Redirect, router } from "expo-router";
-import { ArrowLeft } from "lucide-react-native";
+import { Redirect } from "expo-router";
 import { type ReactElement } from "react";
 import {
   KeyboardAvoidingView,
   Platform,
-  Pressable,
   ScrollView,
   Text,
   View,
@@ -18,6 +16,7 @@ import {
   type EpigramCreateFormValues,
 } from "~/features/epigram-create";
 import { EpigramForm } from "~/widgets/epigram-form";
+import { HeaderBackButton } from "~/widgets/header";
 
 const WRITING_TIPS = [
   "500자 이내의 짧고 인상적인 문장을 담아보세요.",
@@ -33,29 +32,6 @@ const DEFAULT_VALUES: EpigramCreateFormValues = {
   referenceUrl: "",
   tags: [],
 };
-
-function HeaderBar(): ReactElement {
-  function handleBack(): void {
-    if (router.canGoBack()) {
-      router.back();
-      return;
-    }
-    router.replace("/feeds");
-  }
-
-  return (
-    <View className="flex-row items-center px-screen-x py-2">
-      <Pressable
-        onPress={handleBack}
-        accessibilityRole="button"
-        accessibilityLabel="뒤로 가기"
-        className="h-10 w-10 items-center justify-center rounded-full active:bg-blue-200"
-      >
-        <ArrowLeft size={22} color="#454545" />
-      </Pressable>
-    </View>
-  );
-}
 
 function WritingTips(): ReactElement {
   return (
@@ -89,7 +65,9 @@ export function AddEpigramScreen(): ReactElement | null {
 
   return (
     <SafeAreaView className="flex-1 bg-background" edges={["top"]}>
-      <HeaderBar />
+      <View className="flex-row items-center px-screen-x py-2">
+        <HeaderBackButton />
+      </View>
       <KeyboardAvoidingView
         className="flex-1"
         behavior={Platform.OS === "ios" ? "padding" : undefined}

--- a/src/views/epigram-detail/ui/EpigramDetailScreen.tsx
+++ b/src/views/epigram-detail/ui/EpigramDetailScreen.tsx
@@ -1,44 +1,18 @@
 import { Redirect, router } from "expo-router";
-import { ArrowLeft, Pencil } from "lucide-react-native";
+import { Pencil } from "lucide-react-native";
 import { type ReactElement } from "react";
-import {
-  ActivityIndicator,
-  KeyboardAvoidingView,
-  Platform,
-  Pressable,
-  Text,
-  View,
-} from "react-native";
+import { KeyboardAvoidingView, Platform, Pressable, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { useEpigramDetail } from "~/entities/epigram";
 import { useMe } from "~/entities/user";
+import { ErrorState, LoadingState } from "~/shared/ui";
 import { EpigramDetailCard } from "~/widgets/epigram-detail-card";
 import { EpigramDetailList } from "~/widgets/epigram-detail-list";
+import { HeaderBackButton } from "~/widgets/header";
 
 interface EpigramDetailScreenProps {
   epigramId: number;
-}
-
-function BackButton(): ReactElement {
-  function handleBack(): void {
-    if (router.canGoBack()) {
-      router.back();
-      return;
-    }
-    router.replace("/feeds");
-  }
-
-  return (
-    <Pressable
-      onPress={handleBack}
-      accessibilityRole="button"
-      accessibilityLabel="뒤로 가기"
-      className="h-10 w-10 items-center justify-center rounded-full active:bg-blue-200"
-    >
-      <ArrowLeft size={22} color="#454545" />
-    </Pressable>
-  );
 }
 
 interface EditButtonProps {
@@ -62,24 +36,6 @@ function EditButton({ epigramId }: EditButtonProps): ReactElement {
   );
 }
 
-function LoadingState(): ReactElement {
-  return (
-    <View className="flex-1 items-center justify-center">
-      <ActivityIndicator color="#6a82a9" />
-    </View>
-  );
-}
-
-function ErrorState(): ReactElement {
-  return (
-    <View className="flex-1 items-center justify-center px-screen-x">
-      <Text className="font-sans text-base text-error">
-        에피그램을 불러오지 못했습니다
-      </Text>
-    </View>
-  );
-}
-
 export function EpigramDetailScreen({
   epigramId,
 }: EpigramDetailScreenProps): ReactElement | null {
@@ -97,7 +53,9 @@ export function EpigramDetailScreen({
 
   function renderBody(): ReactElement {
     if (isEpigramLoading) return <LoadingState />;
-    if (isError || !epigram) return <ErrorState />;
+    if (isError || !epigram) {
+      return <ErrorState message="에피그램을 불러오지 못했습니다" />;
+    }
     return (
       <EpigramDetailList
         epigramId={epigramId}
@@ -109,12 +67,8 @@ export function EpigramDetailScreen({
   return (
     <SafeAreaView className="flex-1 bg-background" edges={["top"]}>
       <View className="flex-row items-center justify-between px-screen-x py-2">
-        <BackButton />
-        {isOwner ? (
-          <EditButton epigramId={epigramId} />
-        ) : (
-          <View className="w-10" />
-        )}
+        <HeaderBackButton />
+        {isOwner && <EditButton epigramId={epigramId} />}
       </View>
       <KeyboardAvoidingView
         className="flex-1"

--- a/src/views/epigram-edit/ui/EpigramEditScreen.tsx
+++ b/src/views/epigram-edit/ui/EpigramEditScreen.tsx
@@ -1,83 +1,23 @@
-import { Redirect, router } from "expo-router";
-import { ArrowLeft } from "lucide-react-native";
-import { useEffect, useMemo, type ReactElement } from "react";
+import { Redirect } from "expo-router";
+import { type ReactElement } from "react";
 import {
-  ActivityIndicator,
   KeyboardAvoidingView,
   Platform,
-  Pressable,
   ScrollView,
   Text,
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-import { useEpigramDetail, type EpigramDetail } from "~/entities/epigram";
+import { useEpigramDetail } from "~/entities/epigram";
 import { useMe } from "~/entities/user";
-import {
-  AUTHOR_TYPE,
-  type EpigramCreateFormValues,
-} from "~/features/epigram-create";
-import { useEpigramEdit } from "~/features/epigram-edit";
+import { resolveDefaultValues, useEpigramEdit } from "~/features/epigram-edit";
+import { ErrorState, LoadingState } from "~/shared/ui";
 import { EpigramForm } from "~/widgets/epigram-form";
-
-const UNKNOWN_AUTHOR = "알 수 없음";
+import { HeaderBackButton } from "~/widgets/header";
 
 interface EpigramEditScreenProps {
   epigramId: number;
-}
-
-function resolveDefaultValues(epigram: EpigramDetail): EpigramCreateFormValues {
-  const isUnknown = epigram.author === UNKNOWN_AUTHOR;
-  return {
-    content: epigram.content,
-    authorType: isUnknown ? AUTHOR_TYPE.UNKNOWN : AUTHOR_TYPE.DIRECT,
-    authorName: isUnknown ? "" : epigram.author,
-    referenceTitle: epigram.referenceTitle ?? "",
-    referenceUrl: epigram.referenceUrl ?? "",
-    tags: epigram.tags.map((tag) => tag.name),
-  };
-}
-
-function HeaderBar(): ReactElement {
-  function handleBack(): void {
-    if (router.canGoBack()) {
-      router.back();
-      return;
-    }
-    router.replace("/feeds");
-  }
-
-  return (
-    <View className="flex-row items-center px-screen-x py-2">
-      <Pressable
-        onPress={handleBack}
-        accessibilityRole="button"
-        accessibilityLabel="뒤로 가기"
-        className="h-10 w-10 items-center justify-center rounded-full active:bg-blue-200"
-      >
-        <ArrowLeft size={22} color="#454545" />
-      </Pressable>
-    </View>
-  );
-}
-
-function LoadingState(): ReactElement {
-  return (
-    <View className="flex-1 items-center justify-center">
-      <ActivityIndicator color="#6a82a9" />
-    </View>
-  );
-}
-
-function ErrorState(): ReactElement {
-  return (
-    <View className="flex-1 items-center justify-center px-screen-x">
-      <Text className="font-sans text-base text-error">
-        에피그램을 불러오지 못했습니다
-      </Text>
-    </View>
-  );
 }
 
 export function EpigramEditScreen({
@@ -100,28 +40,17 @@ export function EpigramEditScreen({
     submit,
   } = useEpigramEdit(epigramId);
 
-  const isUnauthorized =
-    !isMeLoading &&
-    user !== null &&
-    epigram !== undefined &&
-    epigram.writerId !== user.id;
-
-  useEffect(() => {
-    if (isUnauthorized) router.replace(`/epigrams/${epigramId}`);
-  }, [isUnauthorized, epigramId]);
-
-  const defaultValues = useMemo(
-    () => (epigram ? resolveDefaultValues(epigram) : null),
-    [epigram],
-  );
-
   if (isMeLoading) return null;
   if (!user) return <Redirect href="/login" />;
+  if (epigram && epigram.writerId !== user.id) {
+    return <Redirect href={`/epigrams/${epigramId}`} />;
+  }
 
   function renderBody(): ReactElement {
     if (isEpigramLoading) return <LoadingState />;
-    if (isError || !epigram || !defaultValues) return <ErrorState />;
-    if (isUnauthorized) return <LoadingState />;
+    if (isError || !epigram) {
+      return <ErrorState message="에피그램을 불러오지 못했습니다" />;
+    }
     return (
       <ScrollView
         className="flex-1"
@@ -132,7 +61,7 @@ export function EpigramEditScreen({
           에피그램 수정
         </Text>
         <EpigramForm
-          defaultValues={defaultValues}
+          defaultValues={resolveDefaultValues(epigram)}
           onSubmit={submit}
           isSubmitting={isSubmitting}
           hasError={hasError}
@@ -150,7 +79,9 @@ export function EpigramEditScreen({
 
   return (
     <SafeAreaView className="flex-1 bg-background" edges={["top"]}>
-      <HeaderBar />
+      <View className="flex-row items-center px-screen-x py-2">
+        <HeaderBackButton />
+      </View>
       <KeyboardAvoidingView
         className="flex-1"
         behavior={Platform.OS === "ios" ? "padding" : undefined}

--- a/src/widgets/header/index.ts
+++ b/src/widgets/header/index.ts
@@ -1,0 +1,1 @@
+export { HeaderBackButton } from "./ui/HeaderBackButton";

--- a/src/widgets/header/ui/HeaderBackButton.tsx
+++ b/src/widgets/header/ui/HeaderBackButton.tsx
@@ -1,0 +1,31 @@
+import { router, type Href } from "expo-router";
+import { ArrowLeft } from "lucide-react-native";
+import { type ReactElement } from "react";
+import { Pressable } from "react-native";
+
+interface HeaderBackButtonProps {
+  fallbackHref?: Href;
+}
+
+export function HeaderBackButton({
+  fallbackHref = "/feeds",
+}: HeaderBackButtonProps): ReactElement {
+  function handleBack(): void {
+    if (router.canGoBack()) {
+      router.back();
+      return;
+    }
+    router.replace(fallbackHref);
+  }
+
+  return (
+    <Pressable
+      onPress={handleBack}
+      accessibilityRole="button"
+      accessibilityLabel="뒤로 가기"
+      className="h-10 w-10 items-center justify-center rounded-full active:bg-blue-200"
+    >
+      <ArrowLeft size={22} color="#454545" />
+    </Pressable>
+  );
+}


### PR DESCRIPTION
## ✏️ 작업 내용

### 공통 UI 추출
- `shared/ui/LoadingState`, `shared/ui/ErrorState` 신설 — `EpigramDetailScreen`/`EpigramEditScreen` 중복 제거
- `widgets/header/HeaderBackButton` 신설 — `BackButton` 3곳(Detail/Add/Edit) 중복 제거, `fallbackHref` prop 지원

### 도메인 상수 통합
- `"알 수 없음"` 리터럴(3곳 산재) → `features/epigram-create/model/schema.ts`에 `UNKNOWN_AUTHOR` 단일 export
- `resolveDefaultValues` 헬퍼를 `features/epigram-edit/model`로 이동 후 view에서 import

### EpigramEditScreen 단순화
- `useEffect` 기반 unauthorized 리다이렉트 → 선언적 `<Redirect href={`/epigrams/${id}`} />`
- `useMemo(defaultValues)` 제거 — RHF는 mount 시 1회만 읽음
- `isUnauthorized` 데드 분기(`!isMeLoading && user !== null`) 제거 — early return 이후 자명
- `renderBody` 안의 transient `LoadingState` 폴백 제거 (선언적 Redirect로 도달 불가)

### EpigramDetailScreen
- `<View className="w-10" />` 비가시 spacer 제거 (`justify-between` + 단일 자식이면 자동 좌측 정렬)
- 조건부 EditButton을 ternary → `&&` 로 단순화

## 🗨️ 논의 사항

- 라우트 상수화(`/feeds`, `/login`, `/epigrams/:id/edit` 산재), 컬러 토큰화(`#454545`/`#6a82a9`), 화면 셸 컴포넌트(`SafeAreaView+KeyboardAvoidingView+ScrollView` 셋트)는 cross-cutting 변경이라 별도 이슈로 분리 예정

## 기대효과

- 신규 화면 추가 시 `HeaderBackButton`/`LoadingState`/`ErrorState` 재사용 가능
- EpigramEditScreen 코드량 ~40% 감소(162→90줄), effect-driven 네비게이션 제거로 이동 전 깜빡임 해소
- `UNKNOWN_AUTHOR` 매직 스트링 단일화로 향후 라벨 변경 시 1곳만 수정

## Closes #77