### PR TITLE
feat: 에피그램 삭제 기능 + 디테일 화면 메뉴 진입점 (#79)

### DIFF
--- a/src/entities/epigram/api/deleteEpigram.ts
+++ b/src/entities/epigram/api/deleteEpigram.ts
@@ -1,0 +1,5 @@
+import { apiClient } from "~/shared/api/client";
+
+export async function deleteEpigram(epigramId: number): Promise<void> {
+  await apiClient.delete(`/epigrams/${epigramId}`);
+}

--- a/src/entities/epigram/index.ts
+++ b/src/entities/epigram/index.ts
@@ -13,6 +13,7 @@ export type {
 
 export { createEpigram } from "./api/createEpigram";
 export type { CreateEpigramRequest } from "./api/createEpigram";
+export { deleteEpigram } from "./api/deleteEpigram";
 export { updateEpigram } from "./api/updateEpigram";
 export type { UpdateEpigramRequest } from "./api/updateEpigram";
 export { epigramKeys } from "./api/keys";

--- a/src/features/epigram-delete/index.ts
+++ b/src/features/epigram-delete/index.ts
@@ -1,0 +1,1 @@
+export { useEpigramDelete } from "./model/useEpigramDelete";

--- a/src/features/epigram-delete/model/useEpigramDelete.ts
+++ b/src/features/epigram-delete/model/useEpigramDelete.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { router } from "expo-router";
+import { Alert } from "react-native";
+
+import { deleteEpigram, epigramKeys } from "~/entities/epigram";
+
+interface UseEpigramDeleteReturn {
+  handleDelete: () => void;
+  isDeleting: boolean;
+}
+
+export function useEpigramDelete(epigramId: number): UseEpigramDeleteReturn {
+  const queryClient = useQueryClient();
+
+  const { mutate, isPending: isDeleting } = useMutation({
+    mutationFn: () => deleteEpigram(epigramId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: epigramKeys.all });
+      router.replace("/feeds");
+    },
+    onError: () => {
+      Alert.alert(
+        "삭제 실패",
+        "에피그램을 삭제하지 못했습니다. 잠시 후 다시 시도해주세요.",
+      );
+    },
+  });
+
+  function handleDelete(): void {
+    Alert.alert(
+      "에피그램을 삭제할까요?",
+      "삭제 후에는 복구할 수 없습니다.",
+      [
+        { text: "취소", style: "cancel" },
+        { text: "삭제", style: "destructive", onPress: () => mutate() },
+      ],
+      { cancelable: true },
+    );
+  }
+
+  return { handleDelete, isDeleting };
+}

--- a/src/views/epigram-detail/ui/EpigramDetailScreen.tsx
+++ b/src/views/epigram-detail/ui/EpigramDetailScreen.tsx
@@ -1,11 +1,18 @@
 import { Redirect, router } from "expo-router";
-import { Pencil } from "lucide-react-native";
+import { MoreVertical } from "lucide-react-native";
 import { type ReactElement } from "react";
-import { KeyboardAvoidingView, Platform, Pressable, View } from "react-native";
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  View,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { useEpigramDetail } from "~/entities/epigram";
 import { useMe } from "~/entities/user";
+import { useEpigramDelete } from "~/features/epigram-delete";
 import { ErrorState, LoadingState } from "~/shared/ui";
 import { EpigramDetailCard } from "~/widgets/epigram-detail-card";
 import { EpigramDetailList } from "~/widgets/epigram-detail-list";
@@ -15,23 +22,38 @@ interface EpigramDetailScreenProps {
   epigramId: number;
 }
 
-interface EditButtonProps {
+interface ActionMenuProps {
   epigramId: number;
 }
 
-function EditButton({ epigramId }: EditButtonProps): ReactElement {
-  function handleEdit(): void {
-    router.push(`/epigrams/${epigramId}/edit`);
+function ActionMenu({ epigramId }: ActionMenuProps): ReactElement {
+  const { handleDelete, isDeleting } = useEpigramDelete(epigramId);
+
+  function handleOpenMenu(): void {
+    Alert.alert(
+      "에피그램",
+      undefined,
+      [
+        {
+          text: "수정",
+          onPress: () => router.push(`/epigrams/${epigramId}/edit`),
+        },
+        { text: "삭제", style: "destructive", onPress: handleDelete },
+        { text: "취소", style: "cancel" },
+      ],
+      { cancelable: true },
+    );
   }
 
   return (
     <Pressable
-      onPress={handleEdit}
+      onPress={handleOpenMenu}
+      disabled={isDeleting}
       accessibilityRole="button"
-      accessibilityLabel="에피그램 수정"
+      accessibilityLabel="에피그램 메뉴 열기"
       className="h-10 w-10 items-center justify-center rounded-full active:bg-blue-200"
     >
-      <Pencil size={20} color="#454545" />
+      <MoreVertical size={22} color="#454545" />
     </Pressable>
   );
 }
@@ -68,7 +90,7 @@ export function EpigramDetailScreen({
     <SafeAreaView className="flex-1 bg-background" edges={["top"]}>
       <View className="flex-row items-center justify-between px-screen-x py-2">
         <HeaderBackButton />
-        {isOwner && <EditButton epigramId={epigramId} />}
+        {isOwner && <ActionMenu epigramId={epigramId} />}
       </View>
       <KeyboardAvoidingView
         className="flex-1"


### PR DESCRIPTION
## ✏️ 작업 내용

- `entities/epigram/api/deleteEpigram.ts` — `DELETE /epigrams/:id` 호출 함수 추가, 배럴 재노출
- `features/epigram-delete/model/useEpigramDelete.ts` — 삭제 확인 `Alert.alert` + `useMutation`(성공 시 `epigramKeys.all` 무효화 후 `/feeds` 이동, 실패 시 토스트 Alert) 훅 신설
- `views/epigram-detail/ui/EpigramDetailScreen.tsx` — 연필(Pencil) 단독 버튼을 `MoreVertical` 액션 메뉴로 교체, 수정/삭제를 하나의 Action Sheet에서 선택하도록 변경 (소유자 한정 노출 유지)

## 🗨️ 논의 사항

- 웹은 `ConfirmModal` 기반이지만 모바일은 이미 `useCommentDelete`·`CommentItem`에서 정착된 네이티브 `Alert.alert` 패턴을 따랐습니다.
- 성공 후 이동 경로는 상세 화면이 소멸해야 하므로 `router.replace("/feeds")`로 설정했습니다. 이후 다른 리스트(내가 쓴 글 등)로 돌아가는 요구가 생기면 파라미터화를 고려할 수 있습니다.
- 메뉴 엔트리 아이콘은 댓글 메뉴와 통일되도록 `MoreVertical`로 맞췄습니다.

## 기대효과

- 작성자가 자신의 에피그램을 앱 안에서 바로 삭제할 수 있어 CRUD 루프가 닫힙니다.
- 수정/삭제 두 액션이 동일한 진입점에 모여 헤더가 단순해지고, 추후 신고·공유 등 메뉴 확장도 쉬워집니다.

Closes #79