### PR TITLE
fix: epigrams/[id] index·edit 라우트 헤더 숨김 처리 (#81)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -45,7 +45,14 @@ export default function RootLayout() {
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="login" options={{ headerShown: false }} />
         <Stack.Screen name="signup" options={{ headerShown: false }} />
-        <Stack.Screen name="epigrams/[id]" options={{ headerShown: false }} />
+        <Stack.Screen
+          name="epigrams/[id]/index"
+          options={{ headerShown: false }}
+        />
+        <Stack.Screen
+          name="epigrams/[id]/edit"
+          options={{ headerShown: false }}
+        />
       </Stack>
       <StatusBar style="auto" />
     </QueryProvider>


### PR DESCRIPTION
## ✏️ 작업 내용

- `app/_layout.tsx` — 기존 `<Stack.Screen name="epigrams/[id]" />` 한 줄을 실제 라우트 이름과 매칭되는 `epigrams/[id]/index`, `epigrams/[id]/edit` 두 줄로 교체. 각각 `headerShown: false` 적용.

## 🗨️ 논의 사항

- Sub-PR 3(#76)에서 라우트 구조를 flat(`[id].tsx`) → folder(`[id]/index.tsx` + `edit.tsx`)로 전환하면서 등록명이 어긋난 버그였습니다.
- 대안으로 `app/epigrams/[id]/_layout.tsx`를 만들어 중첩 Stack으로 해결할 수도 있었지만, 현재 `[id]/` 하위가 `index`, `edit` 두 화면뿐이라 루트에서 두 줄로 등록하는 쪽이 더 단순합니다. 향후 하위 라우트가 늘어나면 중첩 레이아웃으로 전환을 고려할 수 있습니다.

## 기대효과

- 에피그램 상세·수정 화면에서 expo-router 기본 헤더와 커스텀 헤더(뒤로가기 + 액션 메뉴)가 중복되어 보이는 문제가 해결됩니다.

Closes #81