### PR TITLE
feat: 마이페이지 프로필 + 로그아웃 (#83)

### DIFF
--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -1,26 +1,7 @@
-import { Redirect } from "expo-router";
 import type { ReactElement } from "react";
-import { Text, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
 
-import { useMe } from "~/entities/user";
+import { MypageScreen } from "~/views/mypage";
 
-export default function MypageScreen(): ReactElement | null {
-  const { user, isLoading } = useMe();
-
-  if (isLoading) return null;
-  if (!user) return <Redirect href="/login" />;
-
-  return (
-    <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 items-center justify-center px-screen-x">
-        <Text className="font-sans text-2xl font-bold text-black-900">
-          마이페이지
-        </Text>
-        <Text className="mt-2 font-sans text-sm text-blue-400">
-          감정 기록·활동 차트
-        </Text>
-      </View>
-    </SafeAreaView>
-  );
+export default function MypageRoute(): ReactElement | null {
+  return <MypageScreen />;
 }

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -2,6 +2,7 @@ export { loginSchema } from "./model/loginSchema";
 export type { LoginFormValues } from "./model/loginSchema";
 export { signUpSchema } from "./model/signUpSchema";
 export type { SignUpFormValues } from "./model/signUpSchema";
+export { useLogout } from "./model/useLogout";
 export { useSessionExpiryRedirect } from "./model/useSessionExpiryRedirect";
 
 export { GuestLoginButton } from "./ui/GuestLoginButton";

--- a/src/features/auth/model/useLogout.ts
+++ b/src/features/auth/model/useLogout.ts
@@ -1,0 +1,37 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { router } from "expo-router";
+import { Alert } from "react-native";
+
+import { logout } from "~/entities/user";
+
+interface UseLogoutReturn {
+  handleLogout: () => void;
+}
+
+export function useLogout(): UseLogoutReturn {
+  const queryClient = useQueryClient();
+
+  async function performLogout(): Promise<void> {
+    await logout();
+    queryClient.clear();
+    router.replace("/login");
+  }
+
+  function handleLogout(): void {
+    Alert.alert(
+      "로그아웃할까요?",
+      undefined,
+      [
+        { text: "취소", style: "cancel" },
+        {
+          text: "로그아웃",
+          style: "destructive",
+          onPress: () => performLogout(),
+        },
+      ],
+      { cancelable: true },
+    );
+  }
+
+  return { handleLogout };
+}

--- a/src/views/mypage/index.ts
+++ b/src/views/mypage/index.ts
@@ -1,0 +1,1 @@
+export { MypageScreen } from "./ui/MypageScreen";

--- a/src/views/mypage/ui/MypageScreen.tsx
+++ b/src/views/mypage/ui/MypageScreen.tsx
@@ -1,0 +1,84 @@
+import { Redirect } from "expo-router";
+import { LogOut, User as UserIcon } from "lucide-react-native";
+import { type ReactElement } from "react";
+import { Image, Pressable, ScrollView, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { useMe } from "~/entities/user";
+import { useLogout } from "~/features/auth";
+import { LoadingState } from "~/shared/ui";
+
+const AVATAR_SIZE = 100;
+
+interface ProfileAvatarProps {
+  image: string | null;
+  nickname: string;
+}
+
+function ProfileAvatar({ image, nickname }: ProfileAvatarProps): ReactElement {
+  if (image) {
+    return (
+      <Image
+        source={{ uri: image }}
+        accessibilityLabel={nickname}
+        style={{
+          width: AVATAR_SIZE,
+          height: AVATAR_SIZE,
+          borderRadius: AVATAR_SIZE / 2,
+        }}
+      />
+    );
+  }
+
+  return (
+    <View
+      className="items-center justify-center rounded-full bg-blue-200"
+      style={{ width: AVATAR_SIZE, height: AVATAR_SIZE }}
+    >
+      <UserIcon size={44} color="#2b6cb0" />
+    </View>
+  );
+}
+
+interface LogoutButtonProps {
+  onPress: () => void;
+}
+
+function LogoutButton({ onPress }: LogoutButtonProps): ReactElement {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel="로그아웃"
+      className="flex-row items-center gap-1.5 rounded-full border border-line-200 px-4 py-1.5 active:bg-blue-100"
+    >
+      <LogOut size={14} color="#7b8caf" />
+      <Text className="font-sans text-xs text-black-400">로그아웃</Text>
+    </Pressable>
+  );
+}
+
+export function MypageScreen(): ReactElement | null {
+  const { user, isLoading } = useMe();
+  const { handleLogout } = useLogout();
+
+  if (isLoading) return <LoadingState />;
+  if (!user) return <Redirect href="/login" />;
+
+  return (
+    <SafeAreaView className="flex-1 bg-background" edges={["top"]}>
+      <ScrollView
+        contentContainerClassName="px-screen-x pb-10 pt-6"
+        showsVerticalScrollIndicator={false}
+      >
+        <View className="items-center gap-3">
+          <ProfileAvatar image={user.image} nickname={user.nickname} />
+          <Text className="font-sans text-xl font-bold text-black-800">
+            {user.nickname}
+          </Text>
+          <LogoutButton onPress={handleLogout} />
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}


### PR DESCRIPTION
## ✏️ 작업 내용

- `features/auth/model/useLogout.ts` — `logout()` API 후 `queryClient.clear()` + `router.replace("/login")`, 사용자 확인용 `Alert.alert` 래퍼 포함
- `features/auth/index.ts` — `useLogout` export 추가
- `views/mypage/ui/MypageScreen.tsx` — 프로필 아바타(이미지 or 기본 `UserIcon`), 닉네임, 로그아웃 버튼. 인증되지 않으면 `/login` 리다이렉트
- `views/mypage/index.ts` — 배럴
- `app/(tabs)/mypage.tsx` — 플레이스홀더 제거, `MypageScreen` 연결

## 🗨️ 논의 사항

- 마이페이지 전체는 5-sub-PR로 분할하는 첫 번째 단계입니다. 이 PR은 골격만 제공하고 감정 선택/달력/탭/이미지 업로드는 후속 PR로 이어집니다.
- 웹은 `useLogout`이 `handleLogout`만 반환하는데, 모바일은 네이티브 `Alert.alert` 확인을 래핑해서 노출했습니다. (기존 `useEpigramDelete`·`useCommentDelete` 패턴과 동일)
- 프로필 이미지는 이번 PR에서는 **표시만** 합니다. 업로드는 Sub-PR 5(`expo-image-picker`)에서 연결 예정.

## 기대효과

- 탭 바에서 마이페이지가 실제 정보를 보여주게 되어 전체 네비게이션의 빈 칸이 사라집니다.
- 로그아웃 경로가 UI에 공식적으로 노출되어 계정 전환·디버깅이 쉬워집니다.

Closes #83