### PR TITLE
feat: 마이페이지 오늘의 감정 선택 (#85)

### DIFF
--- a/src/features/emotion-select/index.ts
+++ b/src/features/emotion-select/index.ts
@@ -1,0 +1,2 @@
+export { EmotionSelector } from "./ui/EmotionSelector";
+export { useEmotionSelect } from "./model/useEmotionSelect";

--- a/src/features/emotion-select/model/useEmotionSelect.ts
+++ b/src/features/emotion-select/model/useEmotionSelect.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  emotionLogKeys,
+  postTodayEmotion,
+  useTodayEmotion,
+  type Emotion,
+  type EmotionLog,
+} from "~/entities/emotion-log";
+import { useMe } from "~/entities/user";
+
+interface UseEmotionSelectReturn {
+  todayEmotion: Emotion | null;
+  isSubmitting: boolean;
+  selectEmotion: (emotion: Emotion) => void;
+}
+
+export function useEmotionSelect(): UseEmotionSelectReturn {
+  const { user } = useMe();
+  const queryClient = useQueryClient();
+  const userId = user?.id ?? 0;
+  const todayKey = emotionLogKeys.today(userId);
+
+  const { data: todayLog } = useTodayEmotion(userId);
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: postTodayEmotion,
+    onMutate: async (emotion) => {
+      await queryClient.cancelQueries({ queryKey: todayKey });
+      const previous = queryClient.getQueryData<EmotionLog | null>(todayKey);
+      queryClient.setQueryData<EmotionLog | null>(todayKey, (old) =>
+        old != null ? { ...old, emotion } : old,
+      );
+      return { previous };
+    },
+    onError: (_err, _emotion, context) => {
+      queryClient.setQueryData(todayKey, context?.previous);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: emotionLogKeys.all });
+    },
+  });
+
+  return {
+    todayEmotion: todayLog?.emotion ?? null,
+    isSubmitting: isPending,
+    selectEmotion: mutate,
+  };
+}

--- a/src/features/emotion-select/ui/EmotionSelector.tsx
+++ b/src/features/emotion-select/ui/EmotionSelector.tsx
@@ -1,0 +1,87 @@
+import { type ReactElement } from "react";
+import { Pressable, Text, View } from "react-native";
+
+import { type Emotion } from "~/entities/emotion-log";
+
+import { useEmotionSelect } from "../model/useEmotionSelect";
+
+interface EmotionOption {
+  value: Emotion;
+  emoji: string;
+  label: string;
+}
+
+const EMOTION_OPTIONS: readonly EmotionOption[] = [
+  { value: "MOVED", emoji: "🥰", label: "감동" },
+  { value: "HAPPY", emoji: "😊", label: "기쁨" },
+  { value: "WORRIED", emoji: "🤔", label: "고민" },
+  { value: "SAD", emoji: "😢", label: "슬픔" },
+  { value: "ANGRY", emoji: "😠", label: "분노" },
+];
+
+interface EmotionButtonProps {
+  option: EmotionOption;
+  isSelected: boolean;
+  disabled: boolean;
+  onPress: () => void;
+}
+
+function EmotionButton({
+  option,
+  isSelected,
+  disabled,
+  onPress,
+}: EmotionButtonProps): ReactElement {
+  const containerClass = isSelected
+    ? "bg-blue-100 border-blue-300"
+    : "bg-background border-line-200";
+  const labelClass = isSelected
+    ? "font-semibold text-black-700"
+    : "font-medium text-black-300";
+
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityRole="button"
+      accessibilityLabel={`${option.label} 감정 선택`}
+      accessibilityState={{ selected: isSelected, disabled }}
+      className="items-center gap-2"
+    >
+      <View
+        className={`h-16 w-16 items-center justify-center rounded-2xl border ${containerClass}`}
+      >
+        <Text style={{ fontSize: 32 }}>{option.emoji}</Text>
+      </View>
+      <Text className={`font-sans text-xs ${labelClass}`}>{option.label}</Text>
+    </Pressable>
+  );
+}
+
+export function EmotionSelector(): ReactElement {
+  const { todayEmotion, isSubmitting, selectEmotion } = useEmotionSelect();
+
+  function handlePress(emotion: Emotion): void {
+    if (isSubmitting || todayEmotion === emotion) return;
+    selectEmotion(emotion);
+  }
+
+  return (
+    <View className="gap-4 rounded-2xl bg-white px-4 py-5">
+      <Text className="font-sans text-base font-semibold text-black-600">
+        오늘의 감정은 어떤가요?
+      </Text>
+      <View className="flex-row items-start justify-between">
+        {EMOTION_OPTIONS.map((option) => (
+          <EmotionButton
+            key={option.value}
+            option={option}
+            isSelected={todayEmotion === option.value}
+            disabled={isSubmitting}
+            onPress={() => handlePress(option.value)}
+          />
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/src/views/mypage/ui/MypageScreen.tsx
+++ b/src/views/mypage/ui/MypageScreen.tsx
@@ -6,6 +6,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 
 import { useMe } from "~/entities/user";
 import { useLogout } from "~/features/auth";
+import { EmotionSelector } from "~/features/emotion-select";
 import { LoadingState } from "~/shared/ui";
 
 const AVATAR_SIZE = 100;
@@ -77,6 +78,9 @@ export function MypageScreen(): ReactElement | null {
             {user.nickname}
           </Text>
           <LogoutButton onPress={handleLogout} />
+        </View>
+        <View className="mt-8">
+          <EmotionSelector />
         </View>
       </ScrollView>
     </SafeAreaView>


### PR DESCRIPTION
## ✏️ 작업 내용

- `features/emotion-select/model/useEmotionSelect.ts` — `useMe` + `useTodayEmotion` + `postTodayEmotion` mutation. optimistic update, 실패 시 이전 값으로 롤백, 성공 시 `emotionLogKeys.all` 무효화
- `features/emotion-select/ui/EmotionSelector.tsx` — 5개 감정 버튼(🥰 😊 🤔 😢 😠). 선택 시 파란 보더/배경으로 하이라이트, 제출 중·동일 선택은 disable
- `features/emotion-select/index.ts` — 배럴
- `views/mypage/ui/MypageScreen.tsx` — 프로필 아래 `<EmotionSelector />` 삽입

## 🗨️ 논의 사항

- 웹은 PNG 자산으로 감정 아이콘을 썼지만 모바일은 **이모지**로 대체해 에셋 파이프라인을 단순화했습니다. iOS·Android 모두 시스템 이모지가 컬러로 잘 렌더링되어 시각적 품질도 유지됩니다.
- `useEmotionSelect`는 내부에서 `useMe`를 호출하지만, MypageScreen이 이미 `<Redirect href="/login">`으로 비로그인 진입을 차단하므로 비로그인 분기는 생략했습니다. 향후 `/feeds` 상단 등 다른 화면에서 이 feature를 재사용할 때 login 분기가 필요하면 그때 훅에 추가합니다.

## 기대효과

- 마이페이지에서 오늘의 감정을 기록할 수 있어, 이후 구현할 감정 달력/파이 차트(Sub-PR 3)의 데이터 소스가 활성화됩니다.
- Optimistic update로 서버 응답 대기 없이 즉시 선택 상태가 반영되어 체감 성능이 좋아집니다.

Closes #85