### PR TITLE
feat: 마이페이지 감정 달력 + 파이 차트 (#87)

### DIFF
--- a/src/views/mypage/ui/MypageScreen.tsx
+++ b/src/views/mypage/ui/MypageScreen.tsx
@@ -8,6 +8,7 @@ import { useMe } from "~/entities/user";
 import { useLogout } from "~/features/auth";
 import { EmotionSelector } from "~/features/emotion-select";
 import { LoadingState } from "~/shared/ui";
+import { MypageActivity } from "~/widgets/mypage-activity";
 
 const AVATAR_SIZE = 100;
 
@@ -81,6 +82,9 @@ export function MypageScreen(): ReactElement | null {
         </View>
         <View className="mt-8">
           <EmotionSelector />
+        </View>
+        <View className="mt-4">
+          <MypageActivity userId={user.id} />
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/src/widgets/mypage-activity/index.ts
+++ b/src/widgets/mypage-activity/index.ts
@@ -1,0 +1,1 @@
+export { MypageActivity } from "./ui/MypageActivity";

--- a/src/widgets/mypage-activity/ui/EmotionCalendar.tsx
+++ b/src/widgets/mypage-activity/ui/EmotionCalendar.tsx
@@ -1,0 +1,237 @@
+import { ChevronLeft, ChevronRight } from "lucide-react-native";
+import { useMemo, useState, type ReactElement } from "react";
+import { Pressable, Text, View } from "react-native";
+
+import { useMonthlyEmotions, type Emotion } from "~/entities/emotion-log";
+
+const EMOTION_EMOJI: Record<Emotion, string> = {
+  MOVED: "🥰",
+  HAPPY: "😊",
+  WORRIED: "🤔",
+  SAD: "😢",
+  ANGRY: "😠",
+};
+
+const WEEKDAY_LABELS = ["일", "월", "화", "수", "목", "금", "토"];
+const TODAY = new Date();
+const TODAY_YEAR = TODAY.getFullYear();
+const TODAY_MONTH = TODAY.getMonth() + 1;
+const TODAY_DATE = TODAY.getDate();
+
+interface CalendarCell {
+  day: number;
+  isCurrentMonth: boolean;
+  dateKey: string;
+}
+
+function padZero(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+function buildCalendarCells(year: number, month: number): CalendarCell[] {
+  const firstDayOfWeek = new Date(year, month - 1, 1).getDay();
+  const daysInMonth = new Date(year, month, 0).getDate();
+  const daysInPrevMonth = new Date(year, month - 1, 0).getDate();
+  const cells: CalendarCell[] = [];
+
+  for (let i = firstDayOfWeek - 1; i >= 0; i--) {
+    const day = daysInPrevMonth - i;
+    const prevMonth = month === 1 ? 12 : month - 1;
+    const prevYear = month === 1 ? year - 1 : year;
+    cells.push({
+      day,
+      isCurrentMonth: false,
+      dateKey: `${prevYear}-${padZero(prevMonth)}-${padZero(day)}`,
+    });
+  }
+
+  for (let d = 1; d <= daysInMonth; d++) {
+    cells.push({
+      day: d,
+      isCurrentMonth: true,
+      dateKey: `${year}-${padZero(month)}-${padZero(d)}`,
+    });
+  }
+
+  const remainder = cells.length % 7;
+  if (remainder !== 0) {
+    const nextMonth = month === 12 ? 1 : month + 1;
+    const nextYear = month === 12 ? year + 1 : year;
+    const toAdd = 7 - remainder;
+    for (let i = 1; i <= toAdd; i++) {
+      cells.push({
+        day: i,
+        isCurrentMonth: false,
+        dateKey: `${nextYear}-${padZero(nextMonth)}-${padZero(i)}`,
+      });
+    }
+  }
+
+  return cells;
+}
+
+interface MonthHeaderProps {
+  year: number;
+  month: number;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+function MonthHeader({
+  year,
+  month,
+  onPrev,
+  onNext,
+}: MonthHeaderProps): ReactElement {
+  return (
+    <View className="mb-4 flex-row items-center justify-between">
+      <Text className="font-sans text-base font-semibold text-black-600">
+        {year}년 {month}월
+      </Text>
+      <View className="flex-row items-center gap-2">
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="이전 달"
+          onPress={onPrev}
+          className="h-8 w-8 items-center justify-center rounded-full active:bg-background"
+        >
+          <ChevronLeft size={18} color="#42526e" />
+        </Pressable>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="다음 달"
+          onPress={onNext}
+          className="h-8 w-8 items-center justify-center rounded-full active:bg-background"
+        >
+          <ChevronRight size={18} color="#42526e" />
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+interface DayCellProps {
+  cell: CalendarCell;
+  emotion: Emotion | undefined;
+  isToday: boolean;
+}
+
+function DayCell({ cell, emotion, isToday }: DayCellProps): ReactElement {
+  const borderClass = isToday ? "border-blue-500" : "border-line-200";
+  const bgClass = cell.isCurrentMonth ? "bg-white" : "bg-background/60";
+  const dayTextClass = cell.isCurrentMonth ? "text-black-500" : "text-gray-200";
+
+  return (
+    <View
+      className={`aspect-square flex-1 items-center justify-center border ${borderClass} ${bgClass}`}
+      style={{ minWidth: 0 }}
+    >
+      {emotion ? (
+        <>
+          <Text className="font-sans text-[10px] font-semibold text-gray-300">
+            {cell.day}
+          </Text>
+          <Text style={{ fontSize: 18, marginTop: 2 }}>
+            {EMOTION_EMOJI[emotion]}
+          </Text>
+        </>
+      ) : (
+        <Text className={`font-sans text-sm font-medium ${dayTextClass}`}>
+          {cell.day}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+interface EmotionCalendarProps {
+  userId: number;
+}
+
+export function EmotionCalendar({
+  userId,
+}: EmotionCalendarProps): ReactElement {
+  const [year, setYear] = useState(TODAY_YEAR);
+  const [month, setMonth] = useState(TODAY_MONTH);
+
+  const { data: emotionLogs = [] } = useMonthlyEmotions({
+    userId,
+    year,
+    month,
+  });
+
+  const emotionByDate = useMemo(() => {
+    const map = new Map<string, Emotion>();
+    for (const log of emotionLogs) {
+      const d = new Date(log.createdAt);
+      const key = `${d.getFullYear()}-${padZero(d.getMonth() + 1)}-${padZero(d.getDate())}`;
+      map.set(key, log.emotion);
+    }
+    return map;
+  }, [emotionLogs]);
+
+  const cells = useMemo(() => buildCalendarCells(year, month), [year, month]);
+
+  function handlePrevMonth(): void {
+    if (month === 1) {
+      setYear((y) => y - 1);
+      setMonth(12);
+      return;
+    }
+    setMonth((m) => m - 1);
+  }
+
+  function handleNextMonth(): void {
+    if (month === 12) {
+      setYear((y) => y + 1);
+      setMonth(1);
+      return;
+    }
+    setMonth((m) => m + 1);
+  }
+
+  function isCellToday(cell: CalendarCell): boolean {
+    return (
+      cell.isCurrentMonth &&
+      year === TODAY_YEAR &&
+      month === TODAY_MONTH &&
+      cell.day === TODAY_DATE
+    );
+  }
+
+  return (
+    <View className="rounded-2xl bg-white px-4 py-5">
+      <MonthHeader
+        year={year}
+        month={month}
+        onPrev={handlePrevMonth}
+        onNext={handleNextMonth}
+      />
+
+      <View className="flex-row">
+        {WEEKDAY_LABELS.map((label) => (
+          <View key={label} className="flex-1 items-center py-2">
+            <Text className="font-sans text-xs font-semibold text-gray-300">
+              {label}
+            </Text>
+          </View>
+        ))}
+      </View>
+
+      <View className="flex-row flex-wrap">
+        {cells.map((cell, index) => (
+          <View
+            key={`${cell.dateKey}-${index}`}
+            style={{ width: `${100 / 7}%` }}
+          >
+            <DayCell
+              cell={cell}
+              emotion={emotionByDate.get(cell.dateKey)}
+              isToday={isCellToday(cell)}
+            />
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/src/widgets/mypage-activity/ui/EmotionPieChart.tsx
+++ b/src/widgets/mypage-activity/ui/EmotionPieChart.tsx
@@ -1,0 +1,182 @@
+import { useMemo, type ReactElement } from "react";
+import { Text, View } from "react-native";
+import Svg, { Circle, G } from "react-native-svg";
+
+import type { Emotion, EmotionLog } from "~/entities/emotion-log";
+
+interface EmotionMeta {
+  label: string;
+  emoji: string;
+  color: string;
+}
+
+const EMOTION_META: Record<Emotion, EmotionMeta> = {
+  MOVED: { label: "감동", emoji: "🥰", color: "#48bb98" },
+  HAPPY: { label: "기쁨", emoji: "😊", color: "#fbc85b" },
+  WORRIED: { label: "고민", emoji: "🤔", color: "#8e80e3" },
+  SAD: { label: "슬픔", emoji: "😢", color: "#5195ee" },
+  ANGRY: { label: "분노", emoji: "😠", color: "#e46e80" },
+};
+
+const EMOTION_ORDER: Emotion[] = ["MOVED", "HAPPY", "WORRIED", "SAD", "ANGRY"];
+
+const CHART_SIZE = 140;
+const RADIUS = 55;
+const STROKE_WIDTH = 18;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+interface ChartDatum {
+  emotion: Emotion;
+  count: number;
+  percentage: number;
+}
+
+function buildChartData(emotionLogs: EmotionLog[]): ChartDatum[] {
+  const counts = new Map<Emotion, number>();
+  for (const log of emotionLogs) {
+    counts.set(log.emotion, (counts.get(log.emotion) ?? 0) + 1);
+  }
+
+  const total = emotionLogs.length;
+  if (total === 0) return [];
+
+  return EMOTION_ORDER.filter((e) => counts.has(e)).map((emotion) => {
+    const count = counts.get(emotion) ?? 0;
+    return {
+      emotion,
+      count,
+      percentage: Math.round((count / total) * 100),
+    };
+  });
+}
+
+interface DonutChartProps {
+  data: ChartDatum[];
+  total: number;
+}
+
+function DonutChart({ data, total }: DonutChartProps): ReactElement {
+  let cumulative = 0;
+  const center = CHART_SIZE / 2;
+
+  return (
+    <Svg width={CHART_SIZE} height={CHART_SIZE}>
+      <G rotation="-90" origin={`${center}, ${center}`}>
+        {data.map(({ emotion, count }) => {
+          const dashLength = (count / total) * CIRCUMFERENCE;
+          const offset = -cumulative;
+          cumulative += dashLength;
+          return (
+            <Circle
+              key={emotion}
+              cx={center}
+              cy={center}
+              r={RADIUS}
+              fill="none"
+              stroke={EMOTION_META[emotion].color}
+              strokeWidth={STROKE_WIDTH}
+              strokeDasharray={`${dashLength} ${CIRCUMFERENCE - dashLength}`}
+              strokeDashoffset={offset}
+            />
+          );
+        })}
+      </G>
+    </Svg>
+  );
+}
+
+interface LegendRowProps {
+  datum: ChartDatum;
+}
+
+function LegendRow({ datum }: LegendRowProps): ReactElement {
+  const meta = EMOTION_META[datum.emotion];
+
+  return (
+    <View className="flex-row items-center gap-2">
+      <Text style={{ fontSize: 16 }}>{meta.emoji}</Text>
+      <Text className="w-8 font-sans text-xs text-black-400">{meta.label}</Text>
+      <View className="h-1.5 flex-1 overflow-hidden rounded-full bg-blue-200">
+        <View
+          className="h-full rounded-full"
+          style={{
+            width: `${datum.percentage}%`,
+            backgroundColor: meta.color,
+          }}
+        />
+      </View>
+      <Text className="w-9 text-right font-sans text-xs font-semibold text-black-600">
+        {datum.percentage}%
+      </Text>
+    </View>
+  );
+}
+
+interface EmotionPieChartProps {
+  emotionLogs: EmotionLog[];
+}
+
+export function EmotionPieChart({
+  emotionLogs,
+}: EmotionPieChartProps): ReactElement {
+  const chartData = useMemo(() => buildChartData(emotionLogs), [emotionLogs]);
+
+  if (chartData.length === 0) {
+    return (
+      <View className="rounded-2xl bg-white px-4 py-5">
+        <Text className="mb-3 font-sans text-base font-semibold text-black-600">
+          감정 차트
+        </Text>
+        <View className="items-center py-8">
+          <Text style={{ fontSize: 36, opacity: 0.3 }}>😊</Text>
+          <Text className="mt-2 font-sans text-sm text-gray-300">
+            이번 달 감정 기록이 없어요
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  const total = chartData.reduce((sum, d) => sum + d.count, 0);
+  const topEmotion = chartData.reduce((max, d) =>
+    d.count > max.count ? d : max,
+  );
+  const topMeta = EMOTION_META[topEmotion.emotion];
+
+  return (
+    <View className="rounded-2xl bg-white px-4 py-5">
+      <Text className="mb-4 font-sans text-base font-semibold text-black-600">
+        감정 차트
+      </Text>
+
+      <View className="flex-row items-center gap-5">
+        <View
+          style={{ width: CHART_SIZE, height: CHART_SIZE }}
+          className="items-center justify-center"
+        >
+          <DonutChart data={chartData} total={total} />
+          <View
+            pointerEvents="none"
+            style={{
+              position: "absolute",
+              width: CHART_SIZE,
+              height: CHART_SIZE,
+            }}
+            className="items-center justify-center"
+          >
+            <Text style={{ fontSize: 28 }}>{topMeta.emoji}</Text>
+            <Text className="font-sans text-xs font-semibold text-black-500">
+              {topMeta.label}
+            </Text>
+          </View>
+        </View>
+
+        <View className="flex-1 gap-2">
+          {chartData.map((datum) => (
+            <LegendRow key={datum.emotion} datum={datum} />
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/src/widgets/mypage-activity/ui/MypageActivity.tsx
+++ b/src/widgets/mypage-activity/ui/MypageActivity.tsx
@@ -1,0 +1,28 @@
+import { type ReactElement } from "react";
+import { View } from "react-native";
+
+import { useMonthlyEmotions } from "~/entities/emotion-log";
+
+import { EmotionCalendar } from "./EmotionCalendar";
+import { EmotionPieChart } from "./EmotionPieChart";
+
+const NOW = new Date();
+
+interface MypageActivityProps {
+  userId: number;
+}
+
+export function MypageActivity({ userId }: MypageActivityProps): ReactElement {
+  const { data: monthlyLogs = [] } = useMonthlyEmotions({
+    userId,
+    year: NOW.getFullYear(),
+    month: NOW.getMonth() + 1,
+  });
+
+  return (
+    <View className="gap-4">
+      <EmotionCalendar userId={userId} />
+      <EmotionPieChart emotionLogs={monthlyLogs} />
+    </View>
+  );
+}


### PR DESCRIPTION
## ✏️ 작업 내용
- `EmotionCalendar` — 외부 라이브러리 없이 7×6 커스텀 그리드로 구현. 월 네비게이션 버튼(ChevronLeft/Right)과 일자별 감정 이모지 표시
- `EmotionPieChart` — `react-native-svg` `Circle` + `strokeDasharray`로 도넛 렌더링. 중앙에 최상위 감정 이모지 + 범례(이모지 / 라벨 / 바 / 퍼센트)
- `MypageActivity` — 달력·차트 조합 위젯. 이번 달 월간 로그 1회 패치
- `MypageScreen` — 감정 선택기 하단에 위젯 삽입

## 🗨️ 논의 사항
- 차트: 웹의 recharts 대신 `react-native-svg` 기본 `Circle` 조합으로 단순화 (사용자 지시: "차트는 최대한 단순하게")
- 달력: 웹과 동일한 커스텀 그리드 패턴 (`buildCalendarCells`) 그대로 포팅
- 감정 아이콘: 모든 시각 요소를 이모지 텍스트로 통일 (PNG asset 파이프라인 생략)
- 필터 드롭다운: 모바일 첫 버전에서는 생략 — 화면 폭 제약과 탭/모달 UX 결정이 필요해 이후 PR에서 다룬다

## 기대효과
- 사용자가 이번 달 감정 분포를 한눈에 파악
- 달력에서 날짜별 감정 흐름을 시각적으로 확인 가능
- 웹 대비 네이티브 환경에서도 동일한 데이터 시각화 경험 제공

Closes #87
