### PR TITLE
feat: 마이페이지 내 에피그램 / 내 댓글 탭 (#89)

### DIFF
--- a/src/widgets/mypage-activity/ui/LoadMoreButton.tsx
+++ b/src/widgets/mypage-activity/ui/LoadMoreButton.tsx
@@ -1,0 +1,32 @@
+import { Plus } from "lucide-react-native";
+import { type ReactElement } from "react";
+import { Pressable, Text, View } from "react-native";
+
+interface LoadMoreButtonProps {
+  label: string;
+  isFetchingNextPage: boolean;
+  onPress: () => void;
+}
+
+export function LoadMoreButton({
+  label,
+  isFetchingNextPage,
+  onPress,
+}: LoadMoreButtonProps): ReactElement {
+  return (
+    <View className="items-center">
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={label}
+        disabled={isFetchingNextPage}
+        onPress={onPress}
+        className="flex-row items-center gap-2 rounded-full border border-line-200 bg-background px-6 py-3 active:bg-blue-100 disabled:opacity-60"
+      >
+        <Plus size={16} color="#5195ee" />
+        <Text className="font-sans text-sm font-medium text-blue-500">
+          {isFetchingNextPage ? "불러오는 중..." : label}
+        </Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/src/widgets/mypage-activity/ui/MyCommentItem.tsx
+++ b/src/widgets/mypage-activity/ui/MyCommentItem.tsx
@@ -1,0 +1,77 @@
+import { router } from "expo-router";
+import { type ReactElement } from "react";
+import { Alert, Pressable, Text, View } from "react-native";
+
+import { WriterAvatar, type Comment } from "~/entities/comment";
+import { useCommentDelete } from "~/features/comment-delete";
+import { formatRelativeTime } from "~/shared/lib/date";
+
+interface MyCommentItemProps {
+  comment: Comment;
+  userId: number;
+}
+
+export function MyCommentItem({
+  comment,
+  userId,
+}: MyCommentItemProps): ReactElement {
+  const epigramId = comment.epigramId;
+  const { deleteComment, isDeleting } = useCommentDelete(
+    comment.id,
+    epigramId,
+    userId,
+  );
+
+  function handleDeletePress(): void {
+    Alert.alert("댓글 삭제", "정말 삭제하시겠습니까?", [
+      { text: "취소", style: "cancel" },
+      {
+        text: "삭제",
+        style: "destructive",
+        onPress: () => deleteComment(),
+      },
+    ]);
+  }
+
+  function handleCardPress(): void {
+    router.push({
+      pathname: "/epigrams/[id]",
+      params: { id: String(epigramId) },
+    });
+  }
+
+  return (
+    <View className="gap-3 border-t border-line-200 bg-background px-4 py-5 first:border-t-0">
+      <View className="flex-row items-start gap-3">
+        <WriterAvatar writer={comment.writer} size={40} />
+
+        <View className="flex-1">
+          <View className="flex-row items-center justify-between">
+            <View className="flex-row items-center gap-2">
+              <Text className="font-sans text-xs text-black-300">
+                {comment.writer.nickname}
+              </Text>
+              <Text className="font-sans text-xs text-black-300">
+                {formatRelativeTime(comment.createdAt)}
+              </Text>
+            </View>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="댓글 삭제"
+              disabled={isDeleting}
+              onPress={handleDeletePress}
+            >
+              <Text className="font-sans text-xs text-error">삭제</Text>
+            </Pressable>
+          </View>
+
+          <Pressable onPress={handleCardPress} className="mt-2">
+            <Text className="font-sans text-sm leading-relaxed text-black-700">
+              {comment.content}
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/src/widgets/mypage-activity/ui/MyCommentList.tsx
+++ b/src/widgets/mypage-activity/ui/MyCommentList.tsx
@@ -1,0 +1,57 @@
+import { useEffect, type ReactElement } from "react";
+import { Text, View } from "react-native";
+
+import { useMyComments } from "~/entities/comment";
+
+import { LoadMoreButton } from "./LoadMoreButton";
+import { MyCommentItem } from "./MyCommentItem";
+
+const PAGE_SIZE = 3;
+
+interface MyCommentListProps {
+  userId: number;
+  onTotalCount: (count: number) => void;
+}
+
+export function MyCommentList({
+  userId,
+  onTotalCount,
+}: MyCommentListProps): ReactElement {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useMyComments({
+      userId,
+      limit: PAGE_SIZE,
+    });
+
+  const comments = data?.pages.flatMap((page) => page.list) ?? [];
+  const totalCount = data?.pages[0]?.totalCount ?? 0;
+
+  useEffect(() => {
+    onTotalCount(totalCount);
+  }, [totalCount, onTotalCount]);
+
+  if (comments.length === 0) {
+    return (
+      <Text className="py-10 text-center font-sans text-sm text-gray-300">
+        작성한 댓글이 없어요.
+      </Text>
+    );
+  }
+
+  return (
+    <View className="gap-0 overflow-hidden rounded-2xl bg-background">
+      {comments.map((comment) => (
+        <MyCommentItem key={comment.id} comment={comment} userId={userId} />
+      ))}
+      {hasNextPage && (
+        <View className="py-4">
+          <LoadMoreButton
+            label="댓글 더보기"
+            isFetchingNextPage={isFetchingNextPage}
+            onPress={() => void fetchNextPage()}
+          />
+        </View>
+      )}
+    </View>
+  );
+}

--- a/src/widgets/mypage-activity/ui/MyEpigramList.tsx
+++ b/src/widgets/mypage-activity/ui/MyEpigramList.tsx
@@ -1,0 +1,66 @@
+import { router } from "expo-router";
+import { useCallback, useEffect, type ReactElement } from "react";
+import { Text, View } from "react-native";
+
+import { useEpigrams } from "~/entities/epigram";
+import { EpigramCard } from "~/widgets/epigram-card";
+
+import { LoadMoreButton } from "./LoadMoreButton";
+
+const PAGE_SIZE = 3;
+
+interface MyEpigramListProps {
+  userId: number;
+  onTotalCount: (count: number) => void;
+}
+
+export function MyEpigramList({
+  userId,
+  onTotalCount,
+}: MyEpigramListProps): ReactElement {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useEpigrams({
+    limit: PAGE_SIZE,
+    writerId: userId,
+  });
+
+  const epigrams = data?.pages.flatMap((page) => page.list) ?? [];
+  const totalCount = data?.pages[0]?.totalCount ?? 0;
+
+  useEffect(() => {
+    onTotalCount(totalCount);
+  }, [totalCount, onTotalCount]);
+
+  const handleCardPress = useCallback((epigramId: number) => {
+    router.push({
+      pathname: "/epigrams/[id]",
+      params: { id: String(epigramId) },
+    });
+  }, []);
+
+  if (epigrams.length === 0) {
+    return (
+      <Text className="py-10 text-center font-sans text-sm text-gray-300">
+        작성한 에피그램이 없어요.
+      </Text>
+    );
+  }
+
+  return (
+    <View className="gap-4">
+      {epigrams.map((epigram) => (
+        <EpigramCard
+          key={epigram.id}
+          epigram={epigram}
+          onPress={handleCardPress}
+        />
+      ))}
+      {hasNextPage && (
+        <LoadMoreButton
+          label="에피그램 더보기"
+          isFetchingNextPage={isFetchingNextPage}
+          onPress={() => void fetchNextPage()}
+        />
+      )}
+    </View>
+  );
+}

--- a/src/widgets/mypage-activity/ui/MypageActivity.tsx
+++ b/src/widgets/mypage-activity/ui/MypageActivity.tsx
@@ -5,6 +5,7 @@ import { useMonthlyEmotions } from "~/entities/emotion-log";
 
 import { EmotionCalendar } from "./EmotionCalendar";
 import { EmotionPieChart } from "./EmotionPieChart";
+import { TabbedSection } from "./TabbedSection";
 
 const NOW = new Date();
 
@@ -23,6 +24,9 @@ export function MypageActivity({ userId }: MypageActivityProps): ReactElement {
     <View className="gap-4">
       <EmotionCalendar userId={userId} />
       <EmotionPieChart emotionLogs={monthlyLogs} />
+      <View className="mt-4">
+        <TabbedSection userId={userId} />
+      </View>
     </View>
   );
 }

--- a/src/widgets/mypage-activity/ui/TabbedSection.tsx
+++ b/src/widgets/mypage-activity/ui/TabbedSection.tsx
@@ -1,0 +1,72 @@
+import { useCallback, useState, type ReactElement } from "react";
+import { Pressable, Text, View } from "react-native";
+
+import { MyCommentList } from "./MyCommentList";
+import { MyEpigramList } from "./MyEpigramList";
+
+type ActiveTab = "epigrams" | "comments";
+
+interface TabButtonProps {
+  label: string;
+  isActive: boolean;
+  onPress: () => void;
+}
+
+function TabButton({ label, isActive, onPress }: TabButtonProps): ReactElement {
+  const textClass = isActive ? "text-black-600" : "text-gray-300";
+
+  return (
+    <Pressable
+      accessibilityRole="tab"
+      accessibilityState={{ selected: isActive }}
+      onPress={onPress}
+    >
+      <Text className={`font-sans text-base font-semibold ${textClass}`}>
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+interface TabbedSectionProps {
+  userId: number;
+}
+
+export function TabbedSection({ userId }: TabbedSectionProps): ReactElement {
+  const [activeTab, setActiveTab] = useState<ActiveTab>("epigrams");
+  const [epigramCount, setEpigramCount] = useState(0);
+  const [commentCount, setCommentCount] = useState(0);
+
+  const handleEpigramCount = useCallback(
+    (count: number) => setEpigramCount(count),
+    [],
+  );
+  const handleCommentCount = useCallback(
+    (count: number) => setCommentCount(count),
+    [],
+  );
+
+  return (
+    <View className="gap-5">
+      <View className="flex-row items-center gap-5">
+        <TabButton
+          label={`내 에피그램(${epigramCount})`}
+          isActive={activeTab === "epigrams"}
+          onPress={() => setActiveTab("epigrams")}
+        />
+        <TabButton
+          label={`내 댓글(${commentCount})`}
+          isActive={activeTab === "comments"}
+          onPress={() => setActiveTab("comments")}
+        />
+      </View>
+
+      <View style={{ display: activeTab === "epigrams" ? "flex" : "none" }}>
+        <MyEpigramList userId={userId} onTotalCount={handleEpigramCount} />
+      </View>
+      <View style={{ display: activeTab === "comments" ? "flex" : "none" }}>
+        <MyCommentList userId={userId} onTotalCount={handleCommentCount} />
+      </View>
+    </View>
+  );
+}


### PR DESCRIPTION
## ✏️ 작업 내용
- `MyEpigramList` — `useEpigrams({ writerId })` 무한스크롤, 기존 `EpigramCard` 재사용. 카드 탭 시 상세 페이지 이동
- `MyCommentItem` — `WriterAvatar` + 닉네임 + 상대시간 + 본문. 삭제는 Alert 확인 후 `useCommentDelete` 호출
- `MyCommentList` — `useMyComments` 무한스크롤
- `TabbedSection` — 탭 토글 + 카운트 표시(`내 에피그램(12)`, `내 댓글(5)`), 양쪽 리스트 `display` 토글로 상시 마운트(카운트 유지)
- `LoadMoreButton` — 양 리스트가 공유하는 공통 "더보기" 버튼

## 🗨️ 논의 사항
- 댓글 "수정" 버튼은 생략 — 웹은 `/epigrams/[id]/edit?commentId=...`로 이동하지만, 모바일 edit 화면은 에피그램 전용이라 `commentId` 파라미터를 받지 않음. 댓글 인라인 수정은 상세 화면(`EpigramDetailScreen`)에서 이미 제공되므로, 본문 영역 탭 시 상세로 이동하도록 처리
- 두 리스트는 모두 `display` 토글로 마운트 유지 → 탭 전환 후 카운트가 사라지지 않음

## 기대효과
- 내가 작성한 에피그램/댓글을 한 화면에서 탭으로 확인
- 댓글 삭제 플로우가 Alert 확인으로 안전하게 동작
- 에피그램 상세 진입 동선이 자연스럽게 연결

Closes #89
