### PR TITLE
feat: 마이페이지 프로필 이미지 업로드 (#91)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
+        "expo-image-picker": "~17.0.10",
         "expo-linking": "~8.0.11",
         "expo-router": "~6.0.23",
         "expo-secure-store": "~15.0.8",
@@ -7118,6 +7119,27 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-6.0.0.tgz",
+      "integrity": "sha512-nKs/xnOGw6ACb4g26xceBD57FKLFkSwEUTDXEDF3Gtcu3MqF3ZIYd3YM+sSb1/z9AKV1dYT7rMSGVNgsveXLIQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-17.0.10.tgz",
+      "integrity": "sha512-a2xrowp2trmvXyUWgX3O6Q2rZaa2C59AqivKI7+bm+wLvMfTEbZgldLX4rEJJhM8xtmEDTNU+lzjtObwzBRGaw==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~6.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
+    "expo-image-picker": "~17.0.10",
     "expo-linking": "~8.0.11",
     "expo-router": "~6.0.23",
     "expo-secure-store": "~15.0.8",

--- a/src/features/profile-image-upload/index.ts
+++ b/src/features/profile-image-upload/index.ts
@@ -1,0 +1,2 @@
+export { ProfileImageUploadButton } from "./ui/ProfileImageUploadButton";
+export { useProfileImageUpload } from "./model/useProfileImageUpload";

--- a/src/features/profile-image-upload/model/useProfileImageUpload.ts
+++ b/src/features/profile-image-upload/model/useProfileImageUpload.ts
@@ -1,0 +1,65 @@
+import { useQueryClient } from "@tanstack/react-query";
+import * as ImagePicker from "expo-image-picker";
+import { useState } from "react";
+import { Alert } from "react-native";
+
+import { updateMe, userKeys } from "~/entities/user";
+import { toUploadImageFile, uploadImage } from "~/shared/api";
+
+interface UseProfileImageUploadReturn {
+  isUploading: boolean;
+  pickAndUpload: () => Promise<void>;
+}
+
+export function useProfileImageUpload(): UseProfileImageUploadReturn {
+  const queryClient = useQueryClient();
+  const [isUploading, setIsUploading] = useState(false);
+
+  async function ensurePermission(): Promise<boolean> {
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (status !== "granted") {
+      Alert.alert(
+        "권한 필요",
+        "프로필 이미지 업로드를 위해 사진 접근 권한이 필요합니다.",
+      );
+      return false;
+    }
+    return true;
+  }
+
+  async function pickAndUpload(): Promise<void> {
+    if (isUploading) return;
+
+    const allowed = await ensurePermission();
+    if (!allowed) return;
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: true,
+      aspect: [1, 1],
+      quality: 0.8,
+    });
+
+    if (result.canceled) return;
+    const asset = result.assets[0];
+    if (!asset) return;
+
+    setIsUploading(true);
+    try {
+      const file = toUploadImageFile(asset);
+      const imageUrl = await uploadImage(file);
+      await updateMe({ image: imageUrl });
+      await queryClient.invalidateQueries({ queryKey: userKeys.me() });
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "이미지 업로드에 실패했습니다. 다시 시도해주세요.";
+      Alert.alert("업로드 실패", message);
+    } finally {
+      setIsUploading(false);
+    }
+  }
+
+  return { isUploading, pickAndUpload };
+}

--- a/src/features/profile-image-upload/ui/ProfileImageUploadButton.tsx
+++ b/src/features/profile-image-upload/ui/ProfileImageUploadButton.tsx
@@ -1,0 +1,90 @@
+import { Camera, User as UserIcon } from "lucide-react-native";
+import { type ReactElement } from "react";
+import {
+  ActivityIndicator,
+  Image,
+  Pressable,
+  View,
+  type ImageStyle,
+} from "react-native";
+
+import { useProfileImageUpload } from "../model/useProfileImageUpload";
+
+const AVATAR_SIZE = 100;
+
+interface ProfileImageUploadButtonProps {
+  image: string | null;
+  nickname: string;
+}
+
+function AvatarContent({
+  image,
+  nickname,
+}: ProfileImageUploadButtonProps): ReactElement {
+  const baseStyle: ImageStyle = {
+    width: AVATAR_SIZE,
+    height: AVATAR_SIZE,
+    borderRadius: AVATAR_SIZE / 2,
+  };
+
+  if (image) {
+    return (
+      <Image
+        source={{ uri: image }}
+        accessibilityLabel={nickname}
+        style={baseStyle}
+      />
+    );
+  }
+
+  return (
+    <View
+      className="items-center justify-center rounded-full bg-blue-200"
+      style={{ width: AVATAR_SIZE, height: AVATAR_SIZE }}
+    >
+      <UserIcon size={44} color="#2b6cb0" />
+    </View>
+  );
+}
+
+export function ProfileImageUploadButton({
+  image,
+  nickname,
+}: ProfileImageUploadButtonProps): ReactElement {
+  const { isUploading, pickAndUpload } = useProfileImageUpload();
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel="프로필 이미지 변경"
+      accessibilityState={{ disabled: isUploading }}
+      disabled={isUploading}
+      onPress={() => {
+        void pickAndUpload();
+      }}
+      className="overflow-hidden rounded-full"
+      style={{ width: AVATAR_SIZE, height: AVATAR_SIZE }}
+    >
+      <AvatarContent image={image} nickname={nickname} />
+
+      <View
+        pointerEvents="none"
+        style={{
+          position: "absolute",
+          right: 2,
+          bottom: 2,
+          width: 32,
+          height: 32,
+          borderRadius: 16,
+        }}
+        className="items-center justify-center bg-blue-500"
+      >
+        {isUploading ? (
+          <ActivityIndicator size="small" color="#ffffff" />
+        ) : (
+          <Camera size={16} color="#ffffff" />
+        )}
+      </View>
+    </Pressable>
+  );
+}

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -6,3 +6,5 @@ export {
   setRefreshToken,
   clearTokens,
 } from "./tokenStorage";
+export { uploadImage, toUploadImageFile } from "./uploadImage";
+export type { UploadImageFile } from "./uploadImage";

--- a/src/shared/api/uploadImage.ts
+++ b/src/shared/api/uploadImage.ts
@@ -1,0 +1,61 @@
+import { apiClient } from "./client";
+
+const ALLOWED_IMAGE_MIME = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "image/avif",
+]);
+
+const ASCII_ONLY = /^[\x20-\x7E]+$/;
+
+export interface UploadImageFile {
+  uri: string;
+  name: string;
+  mimeType: string;
+}
+
+function extractFileName(uri: string): string {
+  const parts = uri.split("/");
+  return parts[parts.length - 1] ?? "upload";
+}
+
+export async function uploadImage(file: UploadImageFile): Promise<string> {
+  if (!ALLOWED_IMAGE_MIME.has(file.mimeType)) {
+    throw new Error(
+      "jpg, png, gif, webp 형식의 이미지만 업로드할 수 있습니다.",
+    );
+  }
+
+  if (!ASCII_ONLY.test(file.name)) {
+    throw new Error("파일명은 영문만 사용할 수 있습니다.");
+  }
+
+  const formData = new FormData();
+  formData.append("image", {
+    uri: file.uri,
+    name: file.name,
+    type: file.mimeType,
+  } as unknown as Blob);
+
+  const response = await apiClient.post<{ url: string }>(
+    "/images/upload",
+    formData,
+    {
+      headers: { "Content-Type": "multipart/form-data" },
+    },
+  );
+
+  return response.data.url;
+}
+
+export function toUploadImageFile(asset: {
+  uri: string;
+  fileName?: string | null;
+  mimeType?: string | null;
+}): UploadImageFile {
+  const name = asset.fileName ?? extractFileName(asset.uri);
+  const mimeType = asset.mimeType ?? "image/jpeg";
+  return { uri: asset.uri, name, mimeType };
+}

--- a/src/views/mypage/ui/MypageScreen.tsx
+++ b/src/views/mypage/ui/MypageScreen.tsx
@@ -1,46 +1,15 @@
 import { Redirect } from "expo-router";
-import { LogOut, User as UserIcon } from "lucide-react-native";
+import { LogOut } from "lucide-react-native";
 import { type ReactElement } from "react";
-import { Image, Pressable, ScrollView, Text, View } from "react-native";
+import { Pressable, ScrollView, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { useMe } from "~/entities/user";
 import { useLogout } from "~/features/auth";
 import { EmotionSelector } from "~/features/emotion-select";
+import { ProfileImageUploadButton } from "~/features/profile-image-upload";
 import { LoadingState } from "~/shared/ui";
 import { MypageActivity } from "~/widgets/mypage-activity";
-
-const AVATAR_SIZE = 100;
-
-interface ProfileAvatarProps {
-  image: string | null;
-  nickname: string;
-}
-
-function ProfileAvatar({ image, nickname }: ProfileAvatarProps): ReactElement {
-  if (image) {
-    return (
-      <Image
-        source={{ uri: image }}
-        accessibilityLabel={nickname}
-        style={{
-          width: AVATAR_SIZE,
-          height: AVATAR_SIZE,
-          borderRadius: AVATAR_SIZE / 2,
-        }}
-      />
-    );
-  }
-
-  return (
-    <View
-      className="items-center justify-center rounded-full bg-blue-200"
-      style={{ width: AVATAR_SIZE, height: AVATAR_SIZE }}
-    >
-      <UserIcon size={44} color="#2b6cb0" />
-    </View>
-  );
-}
 
 interface LogoutButtonProps {
   onPress: () => void;
@@ -74,7 +43,10 @@ export function MypageScreen(): ReactElement | null {
         showsVerticalScrollIndicator={false}
       >
         <View className="items-center gap-3">
-          <ProfileAvatar image={user.image} nickname={user.nickname} />
+          <ProfileImageUploadButton
+            image={user.image}
+            nickname={user.nickname}
+          />
           <Text className="font-sans text-xl font-bold text-black-800">
             {user.nickname}
           </Text>


### PR DESCRIPTION
## ✏️ 작업 내용
- `expo-image-picker` 설치 (Expo SDK 54 호환 버전)
- `src/shared/api/uploadImage.ts` — React Native FormData 형태(`{uri, name, type}`)로 백엔드 `/images/upload`에 직접 POST. MIME/파일명(ASCII) 검증은 웹과 동일
- `src/features/profile-image-upload/model/useProfileImageUpload.ts` — 권한 요청 → 픽커 → `uploadImage` → `updateMe` → `userKeys.me` 무효화. 실패 시 `Alert`
- `src/features/profile-image-upload/ui/ProfileImageUploadButton.tsx` — 원형 아바타 + 우하단 카메라 뱃지. 업로드 중엔 뱃지가 `ActivityIndicator`로 전환
- `src/views/mypage/ui/MypageScreen.tsx` — 기존 정적 `ProfileAvatar` 삭제, `ProfileImageUploadButton`으로 교체

## 🗨️ 논의 사항
- 업로드 경로: 웹이 사용하던 BFF 프록시(`/api/images/upload`)가 모바일엔 없으므로, `apiClient` 기본 baseURL(`{apiBase}/{teamId}`) 기준으로 직접 `/images/upload` 호출
- 픽커 옵션: `allowsEditing: true, aspect: [1,1], quality: 0.8` — 프로필은 정사각 고정이라 크롭 UX가 자연스러움
- 미리보기: 웹은 `URL.createObjectURL` 기반 프리뷰를 유지했지만, 모바일은 업로드 완료 후 `me` 쿼리 무효화만으로 충분 — 대부분의 업로드가 1~2초 내 완료되어 추가 상태가 필요 없음

## 기대효과
- 마이페이지 Sub-PR 5/5 완료 — 마이페이지 전체 기능 확보
- 사용자가 프로필 이미지를 바로 교체 가능

Closes #91
