### PR TITLE
refactor: 마이페이지 FSD 경계 정리 및 감정 메타데이터 통합

### DIFF
--- a/src/entities/emotion-log/index.ts
+++ b/src/entities/emotion-log/index.ts
@@ -4,6 +4,8 @@ export {
   emotionSchema,
 } from "./model/schema";
 export type { Emotion, EmotionLog } from "./model/schema";
+export { EMOTION_META, EMOTION_ORDER } from "./model/meta";
+export type { EmotionMeta } from "./model/meta";
 
 export { emotionLogKeys } from "./api/keys";
 export { postTodayEmotion } from "./api/postTodayEmotion";

--- a/src/entities/emotion-log/model/meta.ts
+++ b/src/entities/emotion-log/model/meta.ts
@@ -1,0 +1,23 @@
+import type { Emotion } from "./schema";
+
+export interface EmotionMeta {
+  label: string;
+  emoji: string;
+  color: string;
+}
+
+export const EMOTION_META: Record<Emotion, EmotionMeta> = {
+  MOVED: { label: "감동", emoji: "🥰", color: "#48bb98" },
+  HAPPY: { label: "기쁨", emoji: "😊", color: "#fbc85b" },
+  WORRIED: { label: "고민", emoji: "🤔", color: "#8e80e3" },
+  SAD: { label: "슬픔", emoji: "😢", color: "#5195ee" },
+  ANGRY: { label: "분노", emoji: "😠", color: "#e46e80" },
+};
+
+export const EMOTION_ORDER: readonly Emotion[] = [
+  "MOVED",
+  "HAPPY",
+  "WORRIED",
+  "SAD",
+  "ANGRY",
+];

--- a/src/entities/epigram/index.ts
+++ b/src/entities/epigram/index.ts
@@ -21,3 +21,5 @@ export { useEpigramDetail } from "./api/useEpigramDetail";
 export { useEpigrams } from "./api/useEpigrams";
 export { useSearchEpigrams } from "./api/useSearchEpigrams";
 export { useTodayEpigram } from "./api/useTodayEpigram";
+
+export { EpigramCard } from "./ui/EpigramCard";

--- a/src/entities/epigram/ui/EpigramCard.tsx
+++ b/src/entities/epigram/ui/EpigramCard.tsx
@@ -1,7 +1,7 @@
 import { memo, type ReactElement } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 
-import type { Epigram } from "~/entities/epigram";
+import type { Epigram } from "../model/schema";
 
 interface EpigramCardProps {
   epigram: Epigram;

--- a/src/features/emotion-select/ui/EmotionSelector.tsx
+++ b/src/features/emotion-select/ui/EmotionSelector.tsx
@@ -1,37 +1,28 @@
 import { type ReactElement } from "react";
 import { Pressable, Text, View } from "react-native";
 
-import { type Emotion } from "~/entities/emotion-log";
+import {
+  EMOTION_META,
+  EMOTION_ORDER,
+  type Emotion,
+} from "~/entities/emotion-log";
 
 import { useEmotionSelect } from "../model/useEmotionSelect";
 
-interface EmotionOption {
-  value: Emotion;
-  emoji: string;
-  label: string;
-}
-
-const EMOTION_OPTIONS: readonly EmotionOption[] = [
-  { value: "MOVED", emoji: "🥰", label: "감동" },
-  { value: "HAPPY", emoji: "😊", label: "기쁨" },
-  { value: "WORRIED", emoji: "🤔", label: "고민" },
-  { value: "SAD", emoji: "😢", label: "슬픔" },
-  { value: "ANGRY", emoji: "😠", label: "분노" },
-];
-
 interface EmotionButtonProps {
-  option: EmotionOption;
+  emotion: Emotion;
   isSelected: boolean;
   disabled: boolean;
   onPress: () => void;
 }
 
 function EmotionButton({
-  option,
+  emotion,
   isSelected,
   disabled,
   onPress,
 }: EmotionButtonProps): ReactElement {
+  const { emoji, label } = EMOTION_META[emotion];
   const containerClass = isSelected
     ? "bg-blue-100 border-blue-300"
     : "bg-background border-line-200";
@@ -44,16 +35,16 @@ function EmotionButton({
       onPress={onPress}
       disabled={disabled}
       accessibilityRole="button"
-      accessibilityLabel={`${option.label} 감정 선택`}
+      accessibilityLabel={`${label} 감정 선택`}
       accessibilityState={{ selected: isSelected, disabled }}
       className="items-center gap-2"
     >
       <View
         className={`h-16 w-16 items-center justify-center rounded-2xl border ${containerClass}`}
       >
-        <Text style={{ fontSize: 32 }}>{option.emoji}</Text>
+        <Text style={{ fontSize: 32 }}>{emoji}</Text>
       </View>
-      <Text className={`font-sans text-xs ${labelClass}`}>{option.label}</Text>
+      <Text className={`font-sans text-xs ${labelClass}`}>{label}</Text>
     </Pressable>
   );
 }
@@ -72,13 +63,13 @@ export function EmotionSelector(): ReactElement {
         오늘의 감정은 어떤가요?
       </Text>
       <View className="flex-row items-start justify-between">
-        {EMOTION_OPTIONS.map((option) => (
+        {EMOTION_ORDER.map((emotion) => (
           <EmotionButton
-            key={option.value}
-            option={option}
-            isSelected={todayEmotion === option.value}
+            key={emotion}
+            emotion={emotion}
+            isSelected={todayEmotion === emotion}
             disabled={isSubmitting}
-            onPress={() => handlePress(option.value)}
+            onPress={() => handlePress(emotion)}
           />
         ))}
       </View>

--- a/src/widgets/epigram-card/index.ts
+++ b/src/widgets/epigram-card/index.ts
@@ -1,1 +1,0 @@
-export { EpigramCard } from "./ui/EpigramCard";

--- a/src/widgets/epigram-feed/ui/EpigramFeed.tsx
+++ b/src/widgets/epigram-feed/ui/EpigramFeed.tsx
@@ -8,8 +8,7 @@ import {
   type ListRenderItem,
 } from "react-native";
 
-import { useEpigrams, type Epigram } from "~/entities/epigram";
-import { EpigramCard } from "~/widgets/epigram-card";
+import { EpigramCard, useEpigrams, type Epigram } from "~/entities/epigram";
 
 const FEED_PAGE_SIZE = 10;
 

--- a/src/widgets/mypage-activity/ui/EmotionCalendar.tsx
+++ b/src/widgets/mypage-activity/ui/EmotionCalendar.tsx
@@ -2,15 +2,11 @@ import { ChevronLeft, ChevronRight } from "lucide-react-native";
 import { useMemo, useState, type ReactElement } from "react";
 import { Pressable, Text, View } from "react-native";
 
-import { useMonthlyEmotions, type Emotion } from "~/entities/emotion-log";
-
-const EMOTION_EMOJI: Record<Emotion, string> = {
-  MOVED: "🥰",
-  HAPPY: "😊",
-  WORRIED: "🤔",
-  SAD: "😢",
-  ANGRY: "😠",
-};
+import {
+  EMOTION_META,
+  useMonthlyEmotions,
+  type Emotion,
+} from "~/entities/emotion-log";
 
 const WEEKDAY_LABELS = ["일", "월", "화", "수", "목", "금", "토"];
 const TODAY = new Date();
@@ -132,7 +128,7 @@ function DayCell({ cell, emotion, isToday }: DayCellProps): ReactElement {
             {cell.day}
           </Text>
           <Text style={{ fontSize: 18, marginTop: 2 }}>
-            {EMOTION_EMOJI[emotion]}
+            {EMOTION_META[emotion].emoji}
           </Text>
         </>
       ) : (

--- a/src/widgets/mypage-activity/ui/EmotionPieChart.tsx
+++ b/src/widgets/mypage-activity/ui/EmotionPieChart.tsx
@@ -2,23 +2,12 @@ import { useMemo, type ReactElement } from "react";
 import { Text, View } from "react-native";
 import Svg, { Circle, G } from "react-native-svg";
 
-import type { Emotion, EmotionLog } from "~/entities/emotion-log";
-
-interface EmotionMeta {
-  label: string;
-  emoji: string;
-  color: string;
-}
-
-const EMOTION_META: Record<Emotion, EmotionMeta> = {
-  MOVED: { label: "감동", emoji: "🥰", color: "#48bb98" },
-  HAPPY: { label: "기쁨", emoji: "😊", color: "#fbc85b" },
-  WORRIED: { label: "고민", emoji: "🤔", color: "#8e80e3" },
-  SAD: { label: "슬픔", emoji: "😢", color: "#5195ee" },
-  ANGRY: { label: "분노", emoji: "😠", color: "#e46e80" },
-};
-
-const EMOTION_ORDER: Emotion[] = ["MOVED", "HAPPY", "WORRIED", "SAD", "ANGRY"];
+import {
+  EMOTION_META,
+  EMOTION_ORDER,
+  type Emotion,
+  type EmotionLog,
+} from "~/entities/emotion-log";
 
 const CHART_SIZE = 140;
 const RADIUS = 55;

--- a/src/widgets/mypage-activity/ui/MyCommentList.tsx
+++ b/src/widgets/mypage-activity/ui/MyCommentList.tsx
@@ -1,34 +1,24 @@
-import { useEffect, type ReactElement } from "react";
+import { type ReactElement } from "react";
 import { Text, View } from "react-native";
 
 import { useMyComments } from "~/entities/comment";
 
 import { LoadMoreButton } from "./LoadMoreButton";
 import { MyCommentItem } from "./MyCommentItem";
-
-const PAGE_SIZE = 3;
+import { MYPAGE_LIST_PAGE_SIZE } from "./constants";
 
 interface MyCommentListProps {
   userId: number;
-  onTotalCount: (count: number) => void;
 }
 
-export function MyCommentList({
-  userId,
-  onTotalCount,
-}: MyCommentListProps): ReactElement {
+export function MyCommentList({ userId }: MyCommentListProps): ReactElement {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useMyComments({
       userId,
-      limit: PAGE_SIZE,
+      limit: MYPAGE_LIST_PAGE_SIZE,
     });
 
   const comments = data?.pages.flatMap((page) => page.list) ?? [];
-  const totalCount = data?.pages[0]?.totalCount ?? 0;
-
-  useEffect(() => {
-    onTotalCount(totalCount);
-  }, [totalCount, onTotalCount]);
 
   if (comments.length === 0) {
     return (

--- a/src/widgets/mypage-activity/ui/MyEpigramList.tsx
+++ b/src/widgets/mypage-activity/ui/MyEpigramList.tsx
@@ -1,34 +1,23 @@
 import { router } from "expo-router";
-import { useCallback, useEffect, type ReactElement } from "react";
+import { useCallback, type ReactElement } from "react";
 import { Text, View } from "react-native";
 
-import { useEpigrams } from "~/entities/epigram";
-import { EpigramCard } from "~/widgets/epigram-card";
+import { EpigramCard, useEpigrams } from "~/entities/epigram";
 
 import { LoadMoreButton } from "./LoadMoreButton";
-
-const PAGE_SIZE = 3;
+import { MYPAGE_LIST_PAGE_SIZE } from "./constants";
 
 interface MyEpigramListProps {
   userId: number;
-  onTotalCount: (count: number) => void;
 }
 
-export function MyEpigramList({
-  userId,
-  onTotalCount,
-}: MyEpigramListProps): ReactElement {
+export function MyEpigramList({ userId }: MyEpigramListProps): ReactElement {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useEpigrams({
-    limit: PAGE_SIZE,
+    limit: MYPAGE_LIST_PAGE_SIZE,
     writerId: userId,
   });
 
   const epigrams = data?.pages.flatMap((page) => page.list) ?? [];
-  const totalCount = data?.pages[0]?.totalCount ?? 0;
-
-  useEffect(() => {
-    onTotalCount(totalCount);
-  }, [totalCount, onTotalCount]);
 
   const handleCardPress = useCallback((epigramId: number) => {
     router.push({

--- a/src/widgets/mypage-activity/ui/TabbedSection.tsx
+++ b/src/widgets/mypage-activity/ui/TabbedSection.tsx
@@ -1,6 +1,10 @@
-import { useCallback, useState, type ReactElement } from "react";
+import { useState, type ReactElement } from "react";
 import { Pressable, Text, View } from "react-native";
 
+import { useMyComments } from "~/entities/comment";
+import { useEpigrams } from "~/entities/epigram";
+
+import { MYPAGE_LIST_PAGE_SIZE } from "./constants";
 import { MyCommentList } from "./MyCommentList";
 import { MyEpigramList } from "./MyEpigramList";
 
@@ -34,17 +38,17 @@ interface TabbedSectionProps {
 
 export function TabbedSection({ userId }: TabbedSectionProps): ReactElement {
   const [activeTab, setActiveTab] = useState<ActiveTab>("epigrams");
-  const [epigramCount, setEpigramCount] = useState(0);
-  const [commentCount, setCommentCount] = useState(0);
 
-  const handleEpigramCount = useCallback(
-    (count: number) => setEpigramCount(count),
-    [],
-  );
-  const handleCommentCount = useCallback(
-    (count: number) => setCommentCount(count),
-    [],
-  );
+  const { data: epigramsData } = useEpigrams({
+    limit: MYPAGE_LIST_PAGE_SIZE,
+    writerId: userId,
+  });
+  const { data: commentsData } = useMyComments({
+    userId,
+    limit: MYPAGE_LIST_PAGE_SIZE,
+  });
+  const epigramCount = epigramsData?.pages[0]?.totalCount ?? 0;
+  const commentCount = commentsData?.pages[0]?.totalCount ?? 0;
 
   return (
     <View className="gap-5">
@@ -62,10 +66,10 @@ export function TabbedSection({ userId }: TabbedSectionProps): ReactElement {
       </View>
 
       <View style={{ display: activeTab === "epigrams" ? "flex" : "none" }}>
-        <MyEpigramList userId={userId} onTotalCount={handleEpigramCount} />
+        <MyEpigramList userId={userId} />
       </View>
       <View style={{ display: activeTab === "comments" ? "flex" : "none" }}>
-        <MyCommentList userId={userId} onTotalCount={handleCommentCount} />
+        <MyCommentList userId={userId} />
       </View>
     </View>
   );

--- a/src/widgets/mypage-activity/ui/constants.ts
+++ b/src/widgets/mypage-activity/ui/constants.ts
@@ -1,0 +1,1 @@
+export const MYPAGE_LIST_PAGE_SIZE = 3;


### PR DESCRIPTION
## ✏️ 작업 내용

- `EpigramCard` 컴포넌트를 `widgets/epigram-card`에서 `entities/epigram/ui`로 이동
  - widget → widget 직접 import (FSD 같은 레이어 슬라이스 간 cross-import 금지) 위반 해소
  - 기존 사용처(`widgets/epigram-feed`, `widgets/mypage-activity`)는 `~/entities/epigram`에서 import
- 감정 메타데이터를 `entities/emotion-log/model/meta.ts`로 단일화
  - 기존에 `EmotionSelector`, `EmotionCalendar`, `EmotionPieChart` 3곳에 흩어져 있던 label/emoji 상수를 `EMOTION_META: Record<Emotion, { label, emoji, color }>`로 통합
  - 표시 순서도 `EMOTION_ORDER`로 공유
- `TabbedSection`의 `onTotalCount` 콜백 리프팅 제거
  - `MyEpigramList` / `MyCommentList`에서 `useEffect(() => onTotalCount(totalCount))`로 부모 state를 업데이트하던 패턴 제거
  - 부모(`TabbedSection`)가 같은 쿼리 키로 `useEpigrams`/`useMyComments`를 직접 구독해 `totalCount` 읽음 (React Query 캐시 중복 제거로 네트워크 호출은 추가되지 않음)
  - `PAGE_SIZE` 상수는 `mypage-activity/ui/constants.ts`로 추출해 자식/부모가 같은 쿼리 키 생성

## 🗨️ 논의 사항 (참고 사항)

- `EpigramCard`를 entities 레이어로 내린 판단은 카드가 에피그램 엔티티의 순수 표현이기 때문. 여러 위젯이 공유하는 비즈니스 UI는 entities/ui에 위치하는 게 FSD 관례
- `EMOTION_META`의 `color`는 차트 전용이지만 label/emoji와 같은 맥락이라 같은 객체에 둠
- 숨겨진 탭에서 비활성 리스트가 여전히 마운트·fetch되는 문제, `flatMap` 결과 useMemo 누락 등 성능 이슈는 후속 PR에서 처리

## 기대효과

- FSD 레이어 규칙 위반 해소 → 의존 방향이 단방향으로 정돈
- 감정 표현(이모지/라벨/컬러) 수정 시 한 곳만 고치면 됨
- 파생 가능한 `totalCount`를 state로 저장하던 리렌더 사이클 제거

Closes #93