### PR TITLE
refactor: 마이페이지 렌더링 효율 개선

### DIFF
--- a/src/widgets/mypage-activity/ui/EmotionCalendar.tsx
+++ b/src/widgets/mypage-activity/ui/EmotionCalendar.tsx
@@ -9,10 +9,6 @@ import {
 } from "~/entities/emotion-log";
 
 const WEEKDAY_LABELS = ["일", "월", "화", "수", "목", "금", "토"];
-const TODAY = new Date();
-const TODAY_YEAR = TODAY.getFullYear();
-const TODAY_MONTH = TODAY.getMonth() + 1;
-const TODAY_DATE = TODAY.getDate();
 
 interface CalendarCell {
   day: number;
@@ -147,8 +143,13 @@ interface EmotionCalendarProps {
 export function EmotionCalendar({
   userId,
 }: EmotionCalendarProps): ReactElement {
-  const [year, setYear] = useState(TODAY_YEAR);
-  const [month, setMonth] = useState(TODAY_MONTH);
+  const today = new Date();
+  const todayYear = today.getFullYear();
+  const todayMonth = today.getMonth() + 1;
+  const todayDate = today.getDate();
+
+  const [year, setYear] = useState(todayYear);
+  const [month, setMonth] = useState(todayMonth);
 
   const { data: emotionLogs = [] } = useMonthlyEmotions({
     userId,
@@ -189,9 +190,9 @@ export function EmotionCalendar({
   function isCellToday(cell: CalendarCell): boolean {
     return (
       cell.isCurrentMonth &&
-      year === TODAY_YEAR &&
-      month === TODAY_MONTH &&
-      cell.day === TODAY_DATE
+      year === todayYear &&
+      month === todayMonth &&
+      cell.day === todayDate
     );
   }
 

--- a/src/widgets/mypage-activity/ui/EmotionPieChart.tsx
+++ b/src/widgets/mypage-activity/ui/EmotionPieChart.tsx
@@ -5,6 +5,7 @@ import Svg, { Circle, G } from "react-native-svg";
 import {
   EMOTION_META,
   EMOTION_ORDER,
+  useMonthlyEmotions,
   type Emotion,
   type EmotionLog,
 } from "~/entities/emotion-log";
@@ -102,12 +103,19 @@ function LegendRow({ datum }: LegendRowProps): ReactElement {
 }
 
 interface EmotionPieChartProps {
-  emotionLogs: EmotionLog[];
+  userId: number;
 }
 
 export function EmotionPieChart({
-  emotionLogs,
+  userId,
 }: EmotionPieChartProps): ReactElement {
+  const now = new Date();
+  const { data: emotionLogs = [] } = useMonthlyEmotions({
+    userId,
+    year: now.getFullYear(),
+    month: now.getMonth() + 1,
+  });
+
   const chartData = useMemo(() => buildChartData(emotionLogs), [emotionLogs]);
 
   if (chartData.length === 0) {

--- a/src/widgets/mypage-activity/ui/MyCommentList.tsx
+++ b/src/widgets/mypage-activity/ui/MyCommentList.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement } from "react";
+import { useMemo, type ReactElement } from "react";
 import { Text, View } from "react-native";
 
 import { useMyComments } from "~/entities/comment";
@@ -18,7 +18,10 @@ export function MyCommentList({ userId }: MyCommentListProps): ReactElement {
       limit: MYPAGE_LIST_PAGE_SIZE,
     });
 
-  const comments = data?.pages.flatMap((page) => page.list) ?? [];
+  const comments = useMemo(
+    () => data?.pages.flatMap((page) => page.list) ?? [],
+    [data],
+  );
 
   if (comments.length === 0) {
     return (

--- a/src/widgets/mypage-activity/ui/MyEpigramList.tsx
+++ b/src/widgets/mypage-activity/ui/MyEpigramList.tsx
@@ -1,5 +1,5 @@
 import { router } from "expo-router";
-import { useCallback, type ReactElement } from "react";
+import { useCallback, useMemo, type ReactElement } from "react";
 import { Text, View } from "react-native";
 
 import { EpigramCard, useEpigrams } from "~/entities/epigram";
@@ -17,7 +17,10 @@ export function MyEpigramList({ userId }: MyEpigramListProps): ReactElement {
     writerId: userId,
   });
 
-  const epigrams = data?.pages.flatMap((page) => page.list) ?? [];
+  const epigrams = useMemo(
+    () => data?.pages.flatMap((page) => page.list) ?? [],
+    [data],
+  );
 
   const handleCardPress = useCallback((epigramId: number) => {
     router.push({

--- a/src/widgets/mypage-activity/ui/MypageActivity.tsx
+++ b/src/widgets/mypage-activity/ui/MypageActivity.tsx
@@ -1,29 +1,19 @@
 import { type ReactElement } from "react";
 import { View } from "react-native";
 
-import { useMonthlyEmotions } from "~/entities/emotion-log";
-
 import { EmotionCalendar } from "./EmotionCalendar";
 import { EmotionPieChart } from "./EmotionPieChart";
 import { TabbedSection } from "./TabbedSection";
-
-const NOW = new Date();
 
 interface MypageActivityProps {
   userId: number;
 }
 
 export function MypageActivity({ userId }: MypageActivityProps): ReactElement {
-  const { data: monthlyLogs = [] } = useMonthlyEmotions({
-    userId,
-    year: NOW.getFullYear(),
-    month: NOW.getMonth() + 1,
-  });
-
   return (
     <View className="gap-4">
       <EmotionCalendar userId={userId} />
-      <EmotionPieChart emotionLogs={monthlyLogs} />
+      <EmotionPieChart userId={userId} />
       <View className="mt-4">
         <TabbedSection userId={userId} />
       </View>

--- a/src/widgets/mypage-activity/ui/TabbedSection.tsx
+++ b/src/widgets/mypage-activity/ui/TabbedSection.tsx
@@ -38,6 +38,9 @@ interface TabbedSectionProps {
 
 export function TabbedSection({ userId }: TabbedSectionProps): ReactElement {
   const [activeTab, setActiveTab] = useState<ActiveTab>("epigrams");
+  const [visitedTabs, setVisitedTabs] = useState<ReadonlySet<ActiveTab>>(
+    () => new Set(["epigrams"]),
+  );
 
   const { data: epigramsData } = useEpigrams({
     limit: MYPAGE_LIST_PAGE_SIZE,
@@ -50,27 +53,37 @@ export function TabbedSection({ userId }: TabbedSectionProps): ReactElement {
   const epigramCount = epigramsData?.pages[0]?.totalCount ?? 0;
   const commentCount = commentsData?.pages[0]?.totalCount ?? 0;
 
+  function handleSelectTab(tab: ActiveTab): void {
+    setActiveTab(tab);
+    if (visitedTabs.has(tab)) return;
+    setVisitedTabs((prev) => new Set(prev).add(tab));
+  }
+
   return (
     <View className="gap-5">
       <View className="flex-row items-center gap-5">
         <TabButton
           label={`내 에피그램(${epigramCount})`}
           isActive={activeTab === "epigrams"}
-          onPress={() => setActiveTab("epigrams")}
+          onPress={() => handleSelectTab("epigrams")}
         />
         <TabButton
           label={`내 댓글(${commentCount})`}
           isActive={activeTab === "comments"}
-          onPress={() => setActiveTab("comments")}
+          onPress={() => handleSelectTab("comments")}
         />
       </View>
 
-      <View style={{ display: activeTab === "epigrams" ? "flex" : "none" }}>
-        <MyEpigramList userId={userId} />
-      </View>
-      <View style={{ display: activeTab === "comments" ? "flex" : "none" }}>
-        <MyCommentList userId={userId} />
-      </View>
+      {visitedTabs.has("epigrams") && (
+        <View style={{ display: activeTab === "epigrams" ? "flex" : "none" }}>
+          <MyEpigramList userId={userId} />
+        </View>
+      )}
+      {visitedTabs.has("comments") && (
+        <View style={{ display: activeTab === "comments" ? "flex" : "none" }}>
+          <MyCommentList userId={userId} />
+        </View>
+      )}
     </View>
   );
 }


### PR DESCRIPTION
## ✏️ 작업 내용

- `TabbedSection`에 lazy mount 도입 — `visitedTabs` Set으로 사용자가 방문한 탭만 실제로 마운트하고, 이후에는 `display: none`으로 keep-alive. 최초 진입 시 비활성 탭(댓글)은 구독조차 시작하지 않아 초기 네트워크·렌더링 비용을 줄임.
- `MyEpigramList`·`MyCommentList`의 `data?.pages.flatMap(...)` 결과를 `useMemo`로 감싸 참조 안정성 확보 — 부모 리렌더 때마다 새 배열이 만들어져 하위 카드들이 불필요하게 재조정되는 것을 방지.
- `useMonthlyEmotions` 중복 구독 제거 — 기존에는 `MypageActivity`가 월간 감정 로그를 fetch해 `EmotionPieChart`에 prop으로 전달하고, `EmotionCalendar`는 자체적으로 또 한 번 fetch했음. 이제 `EmotionPieChart`가 직접 구독하고 `MypageActivity`는 순수 조합 컴포넌트로 단순화.
- `EmotionCalendar`의 모듈 스코프 `TODAY` 상수 제거 — 모듈이 한 번 로드되면 자정을 넘어도 "오늘" 값이 갱신되지 않는 stale 버그를 피하기 위해 렌더 시점에 계산하도록 변경.

## 🗨️ 논의 사항 (참고 사항)

- 같은 `useMonthlyEmotions` 쿼리 키를 `EmotionCalendar`와 `EmotionPieChart`가 동시에 구독하지만 React Query가 중복 네트워크 요청을 자동 dedupe하므로 성능상 문제 없음. 대신 두 곳에서 fetch 원천을 갖게 되어 각 위젯이 독립적으로 재사용 가능해짐.
- lazy mount Set은 `ReadonlySet`으로 타입만 불변 표현하고 `setVisitedTabs`로 새 Set을 만들어 갱신 — 기존 상태 불변성 원칙 유지.

## 기대효과

- 마이페이지 최초 진입 시 댓글 탭 관련 쿼리·렌더링이 지연되어 FCP 부담 감소.
- 긴 목록 스크롤·부모 리렌더 상황에서 카드 컴포넌트들의 불필요한 리렌더가 줄어듦.
- 월간 감정 로그 패치 지점이 명확해져 향후 유지보수가 쉬움.
- 자정 경계에서도 "오늘" 하이라이트가 정상 동작.

Closes #95