### PR TITLE
refactor: 마이페이지 재사용성 정리 (date util · navigate · UserAvatar 통합)

### DIFF
--- a/src/entities/comment/index.ts
+++ b/src/entities/comment/index.ts
@@ -11,5 +11,3 @@ export type { CreateCommentBody, UpdateCommentBody } from "./api/mutations";
 export { useEpigramComments } from "./api/useEpigramComments";
 export { useMyComments } from "./api/useMyComments";
 export { useRecentComments } from "./api/useRecentComments";
-
-export { WriterAvatar } from "./ui/WriterAvatar";

--- a/src/entities/epigram/index.ts
+++ b/src/entities/epigram/index.ts
@@ -23,3 +23,5 @@ export { useSearchEpigrams } from "./api/useSearchEpigrams";
 export { useTodayEpigram } from "./api/useTodayEpigram";
 
 export { EpigramCard } from "./ui/EpigramCard";
+
+export { navigateToEpigram } from "./lib/navigation";

--- a/src/entities/epigram/lib/navigation.ts
+++ b/src/entities/epigram/lib/navigation.ts
@@ -1,0 +1,8 @@
+import { router } from "expo-router";
+
+export function navigateToEpigram(epigramId: number): void {
+  router.push({
+    pathname: "/epigrams/[id]",
+    params: { id: String(epigramId) },
+  });
+}

--- a/src/features/comment-create/ui/CommentForm.tsx
+++ b/src/features/comment-create/ui/CommentForm.tsx
@@ -1,8 +1,7 @@
 import type { ReactElement } from "react";
 import { Text, TextInput, View } from "react-native";
 
-import { WriterAvatar } from "~/entities/comment";
-import { Button, PrivacyToggle } from "~/shared/ui";
+import { Button, PrivacyToggle, UserAvatar } from "~/shared/ui";
 
 import { useCommentCreate } from "../model/useCommentCreate";
 
@@ -39,7 +38,10 @@ export function CommentForm({
 
   return (
     <View className="flex-row gap-3">
-      <WriterAvatar writer={author ?? PLACEHOLDER_AUTHOR} />
+      <UserAvatar
+        image={(author ?? PLACEHOLDER_AUTHOR).image}
+        nickname={(author ?? PLACEHOLDER_AUTHOR).nickname}
+      />
 
       <View className="flex-1 gap-2 rounded-2xl border border-blue-200 bg-white p-3">
         <TextInput

--- a/src/features/comment-delete/model/useCommentDelete.ts
+++ b/src/features/comment-delete/model/useCommentDelete.ts
@@ -6,16 +6,22 @@ import {
   deleteComment as deleteCommentApi,
 } from "~/entities/comment";
 
+interface UseCommentDeleteParams {
+  commentId: number;
+  epigramId: number;
+  userId?: number;
+}
+
 interface UseCommentDeleteReturn {
   deleteComment: () => void;
   isDeleting: boolean;
 }
 
-export function useCommentDelete(
-  commentId: number,
-  epigramId: number,
-  userId?: number,
-): UseCommentDeleteReturn {
+export function useCommentDelete({
+  commentId,
+  epigramId,
+  userId,
+}: UseCommentDeleteParams): UseCommentDeleteReturn {
   const queryClient = useQueryClient();
 
   const { mutate, isPending: isDeleting } = useMutation({

--- a/src/features/profile-image-upload/ui/ProfileImageUploadButton.tsx
+++ b/src/features/profile-image-upload/ui/ProfileImageUploadButton.tsx
@@ -1,12 +1,8 @@
-import { Camera, User as UserIcon } from "lucide-react-native";
+import { Camera } from "lucide-react-native";
 import { type ReactElement } from "react";
-import {
-  ActivityIndicator,
-  Image,
-  Pressable,
-  View,
-  type ImageStyle,
-} from "react-native";
+import { ActivityIndicator, Pressable, View } from "react-native";
+
+import { UserAvatar } from "~/shared/ui";
 
 import { useProfileImageUpload } from "../model/useProfileImageUpload";
 
@@ -15,36 +11,6 @@ const AVATAR_SIZE = 100;
 interface ProfileImageUploadButtonProps {
   image: string | null;
   nickname: string;
-}
-
-function AvatarContent({
-  image,
-  nickname,
-}: ProfileImageUploadButtonProps): ReactElement {
-  const baseStyle: ImageStyle = {
-    width: AVATAR_SIZE,
-    height: AVATAR_SIZE,
-    borderRadius: AVATAR_SIZE / 2,
-  };
-
-  if (image) {
-    return (
-      <Image
-        source={{ uri: image }}
-        accessibilityLabel={nickname}
-        style={baseStyle}
-      />
-    );
-  }
-
-  return (
-    <View
-      className="items-center justify-center rounded-full bg-blue-200"
-      style={{ width: AVATAR_SIZE, height: AVATAR_SIZE }}
-    >
-      <UserIcon size={44} color="#2b6cb0" />
-    </View>
-  );
 }
 
 export function ProfileImageUploadButton({
@@ -65,7 +31,7 @@ export function ProfileImageUploadButton({
       className="overflow-hidden rounded-full"
       style={{ width: AVATAR_SIZE, height: AVATAR_SIZE }}
     >
-      <AvatarContent image={image} nickname={nickname} />
+      <UserAvatar image={image} nickname={nickname} size={AVATAR_SIZE} />
 
       <View
         pointerEvents="none"

--- a/src/shared/lib/date.ts
+++ b/src/shared/lib/date.ts
@@ -1,3 +1,11 @@
+export function padZero(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+export function toDateKey(date: Date): string {
+  return `${date.getFullYear()}-${padZero(date.getMonth() + 1)}-${padZero(date.getDate())}`;
+}
+
 export function formatRelativeTime(dateString: string): string {
   const now = new Date();
   const date = new Date(dateString);

--- a/src/shared/ui/UserAvatar.tsx
+++ b/src/shared/ui/UserAvatar.tsx
@@ -2,20 +2,22 @@ import { User } from "lucide-react-native";
 import type { ReactElement } from "react";
 import { Image, View } from "react-native";
 
-interface WriterAvatarProps {
-  writer: { image: string | null; nickname: string };
+interface UserAvatarProps {
+  image: string | null;
+  nickname: string;
   size?: number;
 }
 
-export function WriterAvatar({
-  writer,
+export function UserAvatar({
+  image,
+  nickname,
   size = 36,
-}: WriterAvatarProps): ReactElement {
-  if (writer.image) {
+}: UserAvatarProps): ReactElement {
+  if (image) {
     return (
       <Image
-        source={{ uri: writer.image }}
-        accessibilityLabel={writer.nickname}
+        source={{ uri: image }}
+        accessibilityLabel={nickname}
         style={{ width: size, height: size, borderRadius: size / 2 }}
       />
     );

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -5,3 +5,4 @@ export { Input } from "./Input";
 export type { InputProps } from "./Input";
 export { LoadingState } from "./LoadingState";
 export { PrivacyToggle } from "./PrivacyToggle";
+export { UserAvatar } from "./UserAvatar";

--- a/src/widgets/epigram-detail-list/ui/CommentItem.tsx
+++ b/src/widgets/epigram-detail-list/ui/CommentItem.tsx
@@ -2,10 +2,11 @@ import { MoreVertical } from "lucide-react-native";
 import { memo, useState, type ReactElement } from "react";
 import { Alert, Pressable, Text, View } from "react-native";
 
-import { WriterAvatar, type Comment } from "~/entities/comment";
+import { type Comment } from "~/entities/comment";
 import { useCommentDelete } from "~/features/comment-delete";
 import { CommentEditForm } from "~/features/comment-edit";
 import { formatRelativeTime } from "~/shared/lib/date";
+import { UserAvatar } from "~/shared/ui";
 
 interface CommentItemProps {
   comment: Comment;
@@ -19,11 +20,11 @@ function CommentItemBase({
   currentUserId,
 }: CommentItemProps): ReactElement {
   const [isEditing, setIsEditing] = useState(false);
-  const { deleteComment } = useCommentDelete(
-    comment.id,
+  const { deleteComment } = useCommentDelete({
+    commentId: comment.id,
     epigramId,
-    currentUserId,
-  );
+    userId: currentUserId,
+  });
   const isOwnComment =
     currentUserId !== undefined && comment.writer.id === currentUserId;
 
@@ -55,7 +56,10 @@ function CommentItemBase({
   return (
     <View className="flex-row gap-3 rounded-xl bg-blue-100 px-4 py-4">
       <View className="shrink-0">
-        <WriterAvatar writer={comment.writer} />
+        <UserAvatar
+          image={comment.writer.image}
+          nickname={comment.writer.nickname}
+        />
       </View>
       <View className="min-w-0 flex-1">
         <View className="flex-row items-start justify-between gap-2">

--- a/src/widgets/epigram-feed/ui/EpigramFeed.tsx
+++ b/src/widgets/epigram-feed/ui/EpigramFeed.tsx
@@ -1,4 +1,3 @@
-import { router } from "expo-router";
 import { useCallback, type ReactElement } from "react";
 import {
   ActivityIndicator,
@@ -8,7 +7,12 @@ import {
   type ListRenderItem,
 } from "react-native";
 
-import { EpigramCard, useEpigrams, type Epigram } from "~/entities/epigram";
+import {
+  EpigramCard,
+  navigateToEpigram,
+  useEpigrams,
+  type Epigram,
+} from "~/entities/epigram";
 
 const FEED_PAGE_SIZE = 10;
 
@@ -68,16 +72,9 @@ export function EpigramFeed(): ReactElement {
 
   const epigrams = data?.pages.flatMap((page) => page.list) ?? [];
 
-  const handleCardPress = useCallback((epigramId: number) => {
-    router.push({
-      pathname: "/epigrams/[id]",
-      params: { id: String(epigramId) },
-    });
-  }, []);
-
   const renderItem = useCallback<ListRenderItem<Epigram>>(
-    ({ item }) => <EpigramCard epigram={item} onPress={handleCardPress} />,
-    [handleCardPress],
+    ({ item }) => <EpigramCard epigram={item} onPress={navigateToEpigram} />,
+    [],
   );
 
   function handleEndReached(): void {

--- a/src/widgets/mypage-activity/ui/EmotionCalendar.tsx
+++ b/src/widgets/mypage-activity/ui/EmotionCalendar.tsx
@@ -7,6 +7,7 @@ import {
   useMonthlyEmotions,
   type Emotion,
 } from "~/entities/emotion-log";
+import { padZero, toDateKey } from "~/shared/lib/date";
 
 const WEEKDAY_LABELS = ["일", "월", "화", "수", "목", "금", "토"];
 
@@ -14,10 +15,6 @@ interface CalendarCell {
   day: number;
   isCurrentMonth: boolean;
   dateKey: string;
-}
-
-function padZero(n: number): string {
-  return String(n).padStart(2, "0");
 }
 
 function buildCalendarCells(year: number, month: number): CalendarCell[] {
@@ -160,9 +157,7 @@ export function EmotionCalendar({
   const emotionByDate = useMemo(() => {
     const map = new Map<string, Emotion>();
     for (const log of emotionLogs) {
-      const d = new Date(log.createdAt);
-      const key = `${d.getFullYear()}-${padZero(d.getMonth() + 1)}-${padZero(d.getDate())}`;
-      map.set(key, log.emotion);
+      map.set(toDateKey(new Date(log.createdAt)), log.emotion);
     }
     return map;
   }, [emotionLogs]);

--- a/src/widgets/mypage-activity/ui/MyCommentItem.tsx
+++ b/src/widgets/mypage-activity/ui/MyCommentItem.tsx
@@ -1,10 +1,11 @@
-import { router } from "expo-router";
 import { type ReactElement } from "react";
 import { Alert, Pressable, Text, View } from "react-native";
 
-import { WriterAvatar, type Comment } from "~/entities/comment";
+import { type Comment } from "~/entities/comment";
+import { navigateToEpigram } from "~/entities/epigram";
 import { useCommentDelete } from "~/features/comment-delete";
 import { formatRelativeTime } from "~/shared/lib/date";
+import { UserAvatar } from "~/shared/ui";
 
 interface MyCommentItemProps {
   comment: Comment;
@@ -16,11 +17,11 @@ export function MyCommentItem({
   userId,
 }: MyCommentItemProps): ReactElement {
   const epigramId = comment.epigramId;
-  const { deleteComment, isDeleting } = useCommentDelete(
-    comment.id,
+  const { deleteComment, isDeleting } = useCommentDelete({
+    commentId: comment.id,
     epigramId,
     userId,
-  );
+  });
 
   function handleDeletePress(): void {
     Alert.alert("댓글 삭제", "정말 삭제하시겠습니까?", [
@@ -34,16 +35,17 @@ export function MyCommentItem({
   }
 
   function handleCardPress(): void {
-    router.push({
-      pathname: "/epigrams/[id]",
-      params: { id: String(epigramId) },
-    });
+    navigateToEpigram(epigramId);
   }
 
   return (
     <View className="gap-3 border-t border-line-200 bg-background px-4 py-5 first:border-t-0">
       <View className="flex-row items-start gap-3">
-        <WriterAvatar writer={comment.writer} size={40} />
+        <UserAvatar
+          image={comment.writer.image}
+          nickname={comment.writer.nickname}
+          size={40}
+        />
 
         <View className="flex-1">
           <View className="flex-row items-center justify-between">

--- a/src/widgets/mypage-activity/ui/MyEpigramList.tsx
+++ b/src/widgets/mypage-activity/ui/MyEpigramList.tsx
@@ -1,8 +1,11 @@
-import { router } from "expo-router";
-import { useCallback, useMemo, type ReactElement } from "react";
+import { useMemo, type ReactElement } from "react";
 import { Text, View } from "react-native";
 
-import { EpigramCard, useEpigrams } from "~/entities/epigram";
+import {
+  EpigramCard,
+  navigateToEpigram,
+  useEpigrams,
+} from "~/entities/epigram";
 
 import { LoadMoreButton } from "./LoadMoreButton";
 import { MYPAGE_LIST_PAGE_SIZE } from "./constants";
@@ -22,13 +25,6 @@ export function MyEpigramList({ userId }: MyEpigramListProps): ReactElement {
     [data],
   );
 
-  const handleCardPress = useCallback((epigramId: number) => {
-    router.push({
-      pathname: "/epigrams/[id]",
-      params: { id: String(epigramId) },
-    });
-  }, []);
-
   if (epigrams.length === 0) {
     return (
       <Text className="py-10 text-center font-sans text-sm text-gray-300">
@@ -43,7 +39,7 @@ export function MyEpigramList({ userId }: MyEpigramListProps): ReactElement {
         <EpigramCard
           key={epigram.id}
           epigram={epigram}
-          onPress={handleCardPress}
+          onPress={navigateToEpigram}
         />
       ))}
       {hasNextPage && (

--- a/src/widgets/mypage-activity/ui/MypageActivity.tsx
+++ b/src/widgets/mypage-activity/ui/MypageActivity.tsx
@@ -14,9 +14,7 @@ export function MypageActivity({ userId }: MypageActivityProps): ReactElement {
     <View className="gap-4">
       <EmotionCalendar userId={userId} />
       <EmotionPieChart userId={userId} />
-      <View className="mt-4">
-        <TabbedSection userId={userId} />
-      </View>
+      <TabbedSection userId={userId} />
     </View>
   );
 }


### PR DESCRIPTION
## ✏️ 작업 내용

- `WriterAvatar`(entities/comment)와 `ProfileImageUploadButton` 내부 `AvatarContent`가 거의 동일한 원형 이미지/플레이스홀더 로직을 각자 구현하고 있었음. 이를 `shared/ui/UserAvatar`로 승격해 단일 구현으로 통합.
  - `ProfileImageUploadButton`에서 `AvatarContent` 제거 → `<UserAvatar size={100} />` 사용.
  - `MyCommentItem`, `CommentItem`, `CommentForm`이 `{ image, nickname }` 플랫 props로 직접 사용.
- `padZero` / `toDateKey` 날짜 포맷 헬퍼를 `shared/lib/date`로 추출. `EmotionCalendar`가 모듈 내부에서 재정의하던 것을 제거하고 공통 유틸을 사용하도록 변경.
- `navigateToEpigram(epigramId)` 헬퍼를 `entities/epigram/lib/navigation`에 추가. `MyEpigramList`, `MyCommentItem`, `EpigramFeed` 세 곳에서 반복되던 `router.push({ pathname: "/epigrams/[id]", params: { id: String(...) } })` 블록을 대체.
- `useCommentDelete` 시그니처를 positional args `(commentId, epigramId, userId?)` → 객체 파라미터 `{ commentId, epigramId, userId? }`로 변경. 호출부에서 각 인자의 의미가 명확해짐.
- `MypageActivity`의 불필요한 `<View className="mt-4">` 래퍼 제거 — 부모가 이미 `gap-4`를 가져 레이아웃 간격이 이중으로 쌓이고 있었음.

## 🗨️ 논의 사항 (참고 사항)

- `WriterAvatar`는 `writer` 객체를 받았지만 `UserAvatar`는 `image`/`nickname`을 플랫하게 받음 — 호출부 한 줄이 두 줄로 늘지만, 도메인 타입(`Writer`)에 묶이지 않아 프로필 아바타·기본 사용자 아바타 등 어디서든 재사용 가능.
- `navigateToEpigram`은 `entities/epigram`에 두어 라우팅 경로가 이 엔티티의 책임임을 명시. FSD 상위 레이어(widgets, features)에서 자유롭게 import 가능.

## 기대효과

- 아바타·날짜·네비게이션 등 중복 코드 제거로 라인 수 약 105 → 90 줄 감소.
- `useCommentDelete` 호출부 가독성 향상 (arg 순서 헷갈림 방지).
- 날짜 포맷이 필요한 향후 위젯이 재구현 없이 `shared/lib/date`를 사용 가능.
- 마이페이지 레이아웃 간격 일관성 확보.

Closes #97