### PR TITLE
feat: 라우트 보호 구현 (#99)

### DIFF
--- a/app/(tabs)/addepigram.tsx
+++ b/app/(tabs)/addepigram.tsx
@@ -1,7 +1,12 @@
 import type { ReactElement } from "react";
 
+import { AuthGate } from "~/features/auth";
 import { AddEpigramScreen } from "~/views/add-epigram";
 
-export default function AddEpigramRoute(): ReactElement | null {
-  return <AddEpigramScreen />;
+export default function AddEpigramRoute(): ReactElement {
+  return (
+    <AuthGate mode="protected">
+      <AddEpigramScreen />
+    </AuthGate>
+  );
 }

--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -1,7 +1,12 @@
 import type { ReactElement } from "react";
 
+import { AuthGate } from "~/features/auth";
 import { MypageScreen } from "~/views/mypage";
 
-export default function MypageRoute(): ReactElement | null {
-  return <MypageScreen />;
+export default function MypageRoute(): ReactElement {
+  return (
+    <AuthGate mode="protected">
+      <MypageScreen />
+    </AuthGate>
+  );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -11,7 +11,7 @@ import { StatusBar } from "expo-status-bar";
 import { useEffect } from "react";
 import "react-native-reanimated";
 
-import { useSessionExpiryRedirect } from "~/features/auth";
+import { useAuthStore, useSessionExpiryRedirect } from "~/features/auth";
 import { QueryProvider } from "~/shared/api/QueryProvider";
 
 SplashScreen.preventAutoHideAsync();
@@ -28,6 +28,10 @@ export default function RootLayout() {
   });
 
   useSessionExpiryRedirect();
+
+  useEffect(() => {
+    void useAuthStore.getState().initialize();
+  }, []);
 
   useEffect(() => {
     if (fontsLoaded || fontsError) {

--- a/app/epigrams/[id]/edit.tsx
+++ b/app/epigrams/[id]/edit.tsx
@@ -1,6 +1,7 @@
 import { useLocalSearchParams } from "expo-router";
 import type { ReactElement } from "react";
 
+import { AuthGate } from "~/features/auth";
 import { EpigramEditScreen } from "~/views/epigram-edit";
 
 export default function EpigramEditRoute(): ReactElement | null {
@@ -9,5 +10,9 @@ export default function EpigramEditRoute(): ReactElement | null {
 
   if (!Number.isInteger(epigramId) || epigramId <= 0) return null;
 
-  return <EpigramEditScreen epigramId={epigramId} />;
+  return (
+    <AuthGate mode="protected">
+      <EpigramEditScreen epigramId={epigramId} />
+    </AuthGate>
+  );
 }

--- a/app/epigrams/[id]/index.tsx
+++ b/app/epigrams/[id]/index.tsx
@@ -1,6 +1,7 @@
 import { useLocalSearchParams } from "expo-router";
 import type { ReactElement } from "react";
 
+import { AuthGate } from "~/features/auth";
 import { EpigramDetailScreen } from "~/views/epigram-detail";
 
 export default function EpigramDetailRoute(): ReactElement | null {
@@ -9,5 +10,9 @@ export default function EpigramDetailRoute(): ReactElement | null {
 
   if (!Number.isInteger(epigramId) || epigramId <= 0) return null;
 
-  return <EpigramDetailScreen epigramId={epigramId} />;
+  return (
+    <AuthGate mode="protected">
+      <EpigramDetailScreen epigramId={epigramId} />
+    </AuthGate>
+  );
 }

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -1,3 +1,12 @@
-import { LoginScreen } from '~/views/login';
+import type { ReactElement } from "react";
 
-export default LoginScreen;
+import { AuthGate } from "~/features/auth";
+import { LoginScreen } from "~/views/login";
+
+export default function LoginRoute(): ReactElement {
+  return (
+    <AuthGate mode="auth-only">
+      <LoginScreen />
+    </AuthGate>
+  );
+}

--- a/app/signup.tsx
+++ b/app/signup.tsx
@@ -1,3 +1,12 @@
-import { SignUpScreen } from '~/views/signup';
+import type { ReactElement } from "react";
 
-export default SignUpScreen;
+import { AuthGate } from "~/features/auth";
+import { SignUpScreen } from "~/views/signup";
+
+export default function SignUpRoute(): ReactElement {
+  return (
+    <AuthGate mode="auth-only">
+      <SignUpScreen />
+    </AuthGate>
+  );
+}

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,3 +1,4 @@
+export { useAuthStore } from "./model/authStore";
 export { loginSchema } from "./model/loginSchema";
 export type { LoginFormValues } from "./model/loginSchema";
 export { signUpSchema } from "./model/signUpSchema";
@@ -5,6 +6,7 @@ export type { SignUpFormValues } from "./model/signUpSchema";
 export { useLogout } from "./model/useLogout";
 export { useSessionExpiryRedirect } from "./model/useSessionExpiryRedirect";
 
+export { AuthGate } from "./ui/AuthGate";
 export { GuestLoginButton } from "./ui/GuestLoginButton";
 export { LoginForm } from "./ui/LoginForm";
 export { SignUpForm } from "./ui/SignUpForm";

--- a/src/features/auth/model/authStore.ts
+++ b/src/features/auth/model/authStore.ts
@@ -1,0 +1,33 @@
+import { create } from "zustand";
+
+import {
+  clearTokens,
+  getAccessToken,
+  getRefreshToken,
+} from "~/shared/api/tokenStorage";
+
+type AuthStatus = "unknown" | "authenticated" | "unauthenticated";
+
+interface AuthStore {
+  status: AuthStatus;
+  initialize: () => Promise<void>;
+  setAuthenticated: () => void;
+  setUnauthenticated: () => Promise<void>;
+}
+
+export const useAuthStore = create<AuthStore>((set) => ({
+  status: "unknown",
+  initialize: async () => {
+    const [access, refresh] = await Promise.all([
+      getAccessToken(),
+      getRefreshToken(),
+    ]);
+    const hasToken = Boolean(access) || Boolean(refresh);
+    set({ status: hasToken ? "authenticated" : "unauthenticated" });
+  },
+  setAuthenticated: () => set({ status: "authenticated" }),
+  setUnauthenticated: async () => {
+    await clearTokens();
+    set({ status: "unauthenticated" });
+  },
+}));

--- a/src/features/auth/model/useLogout.ts
+++ b/src/features/auth/model/useLogout.ts
@@ -2,7 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { router } from "expo-router";
 import { Alert } from "react-native";
 
-import { logout } from "~/entities/user";
+import { useAuthStore } from "./authStore";
 
 interface UseLogoutReturn {
   handleLogout: () => void;
@@ -12,7 +12,7 @@ export function useLogout(): UseLogoutReturn {
   const queryClient = useQueryClient();
 
   async function performLogout(): Promise<void> {
-    await logout();
+    await useAuthStore.getState().setUnauthenticated();
     queryClient.clear();
     router.replace("/login");
   }

--- a/src/features/auth/model/useSessionExpiryRedirect.ts
+++ b/src/features/auth/model/useSessionExpiryRedirect.ts
@@ -3,9 +3,12 @@ import { useEffect } from "react";
 
 import { setOnSessionExpired } from "~/shared/api/client";
 
+import { useAuthStore } from "./authStore";
+
 export function useSessionExpiryRedirect(): void {
   useEffect(() => {
     setOnSessionExpired(() => {
+      void useAuthStore.getState().setUnauthenticated();
       router.replace("/login");
     });
     return () => {

--- a/src/features/auth/ui/AuthGate.tsx
+++ b/src/features/auth/ui/AuthGate.tsx
@@ -1,0 +1,31 @@
+import { Redirect, usePathname } from "expo-router";
+import type { ReactElement, ReactNode } from "react";
+
+import { LoadingState } from "~/shared/ui";
+
+import { useAuthStore } from "../model/authStore";
+
+type AuthGateMode = "protected" | "auth-only";
+
+interface AuthGateProps {
+  mode: AuthGateMode;
+  children: ReactNode;
+}
+
+export function AuthGate({ mode, children }: AuthGateProps): ReactElement {
+  const status = useAuthStore((s) => s.status);
+  const pathname = usePathname();
+
+  if (status === "unknown") return <LoadingState />;
+
+  if (mode === "protected" && status !== "authenticated") {
+    const redirectParam = encodeURIComponent(pathname);
+    return <Redirect href={`/login?redirect=${redirectParam}`} />;
+  }
+
+  if (mode === "auth-only" && status === "authenticated") {
+    return <Redirect href="/feeds" />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/features/auth/ui/GuestLoginButton.tsx
+++ b/src/features/auth/ui/GuestLoginButton.tsx
@@ -6,6 +6,8 @@ import { ActivityIndicator, Pressable, Text, View } from "react-native";
 import { signIn, userKeys } from "~/entities/user";
 import { cn } from "~/shared/lib/cn";
 
+import { useAuthStore } from "../model/authStore";
+
 const GUEST_CREDENTIALS = {
   email: "guest13325@naver.com",
   password: "@qwer1234",
@@ -22,6 +24,7 @@ export function GuestLoginButton(): ReactElement {
     try {
       const { user } = await signIn(GUEST_CREDENTIALS);
       queryClient.setQueryData(userKeys.me(), user);
+      useAuthStore.getState().setAuthenticated();
       router.replace("/feeds");
     } catch {
       setError("게스트 로그인에 실패했습니다. 잠시 후 다시 시도해주세요.");

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
-import { router } from "expo-router";
+import { router, useLocalSearchParams, type Href } from "expo-router";
 import type { ReactElement } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { View } from "react-native";
@@ -8,12 +8,26 @@ import { View } from "react-native";
 import { signIn, userKeys } from "~/entities/user";
 import { Button, Input } from "~/shared/ui";
 
+import { useAuthStore } from "../model/authStore";
 import { loginSchema, type LoginFormValues } from "../model/loginSchema";
 
 const DEFAULT_VALUES: LoginFormValues = { email: "", password: "" };
+const DEFAULT_REDIRECT: Href = "/feeds";
+
+function resolveRedirectTarget(redirect: string | undefined): Href {
+  if (!redirect) return DEFAULT_REDIRECT;
+  try {
+    const decoded = decodeURIComponent(redirect);
+    if (decoded.startsWith("/")) return decoded as Href;
+    return DEFAULT_REDIRECT;
+  } catch {
+    return DEFAULT_REDIRECT;
+  }
+}
 
 export function LoginForm(): ReactElement {
   const queryClient = useQueryClient();
+  const { redirect } = useLocalSearchParams<{ redirect?: string }>();
   const {
     control,
     handleSubmit,
@@ -29,7 +43,8 @@ export function LoginForm(): ReactElement {
     try {
       const { user } = await signIn(data);
       queryClient.setQueryData(userKeys.me(), user);
-      router.replace("/feeds");
+      useAuthStore.getState().setAuthenticated();
+      router.replace(resolveRedirectTarget(redirect));
     } catch {
       const message = "이메일 혹은 비밀번호를 확인해주세요.";
       setError("email", { message });

--- a/src/features/auth/ui/SignUpForm.tsx
+++ b/src/features/auth/ui/SignUpForm.tsx
@@ -9,6 +9,7 @@ import { View } from "react-native";
 import { signUp, userKeys } from "~/entities/user";
 import { Button, Input } from "~/shared/ui";
 
+import { useAuthStore } from "../model/authStore";
 import { signUpSchema, type SignUpFormValues } from "../model/signUpSchema";
 
 const DEFAULT_VALUES: SignUpFormValues = {
@@ -35,6 +36,7 @@ export function SignUpForm(): ReactElement {
     try {
       const { user } = await signUp(data);
       queryClient.setQueryData(userKeys.me(), user);
+      useAuthStore.getState().setAuthenticated();
       router.replace("/feeds");
     } catch (error) {
       if (isAxiosError(error) && error.response?.status === 500) {

--- a/src/views/add-epigram/ui/AddEpigramScreen.tsx
+++ b/src/views/add-epigram/ui/AddEpigramScreen.tsx
@@ -1,4 +1,3 @@
-import { Redirect } from "expo-router";
 import { type ReactElement } from "react";
 import {
   KeyboardAvoidingView,
@@ -15,6 +14,7 @@ import {
   useEpigramCreate,
   type EpigramCreateFormValues,
 } from "~/features/epigram-create";
+import { LoadingState } from "~/shared/ui";
 import { EpigramForm } from "~/widgets/epigram-form";
 import { HeaderBackButton } from "~/widgets/header";
 
@@ -60,8 +60,7 @@ export function AddEpigramScreen(): ReactElement | null {
     submit,
   } = useEpigramCreate(user?.nickname);
 
-  if (isMeLoading) return null;
-  if (!user) return <Redirect href="/login" />;
+  if (isMeLoading || !user) return <LoadingState />;
 
   return (
     <SafeAreaView className="flex-1 bg-background" edges={["top"]}>

--- a/src/views/epigram-detail/ui/EpigramDetailScreen.tsx
+++ b/src/views/epigram-detail/ui/EpigramDetailScreen.tsx
@@ -1,4 +1,4 @@
-import { Redirect, router } from "expo-router";
+import { router } from "expo-router";
 import { MoreVertical } from "lucide-react-native";
 import { type ReactElement } from "react";
 import {
@@ -68,8 +68,7 @@ export function EpigramDetailScreen({
     isError,
   } = useEpigramDetail(epigramId);
 
-  if (isMeLoading) return null;
-  if (!user) return <Redirect href="/login" />;
+  if (isMeLoading || !user) return <LoadingState />;
 
   const isOwner = epigram !== undefined && epigram.writerId === user.id;
 

--- a/src/views/epigram-edit/ui/EpigramEditScreen.tsx
+++ b/src/views/epigram-edit/ui/EpigramEditScreen.tsx
@@ -40,8 +40,7 @@ export function EpigramEditScreen({
     submit,
   } = useEpigramEdit(epigramId);
 
-  if (isMeLoading) return null;
-  if (!user) return <Redirect href="/login" />;
+  if (isMeLoading || !user) return <LoadingState />;
   if (epigram && epigram.writerId !== user.id) {
     return <Redirect href={`/epigrams/${epigramId}`} />;
   }

--- a/src/views/login/ui/LoginScreen.tsx
+++ b/src/views/login/ui/LoginScreen.tsx
@@ -1,17 +1,18 @@
-import { Redirect, router } from "expo-router";
+import { router } from "expo-router";
 import type { ReactElement } from "react";
-import { KeyboardAvoidingView, Platform, Pressable, ScrollView, Text, View } from "react-native";
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-import { useMe } from "~/entities/user";
 import { GuestLoginButton, LoginForm } from "~/features/auth";
 
-export function LoginScreen(): ReactElement | null {
-  const { user, isLoading } = useMe();
-
-  if (isLoading) return null;
-  if (user) return <Redirect href="/feeds" />;
-
+export function LoginScreen(): ReactElement {
   function handleGoToSignUp(): void {
     router.push("/signup");
   }
@@ -28,17 +29,25 @@ export function LoginScreen(): ReactElement | null {
           keyboardShouldPersistTaps="handled"
         >
           <View className="mb-10 items-center gap-2">
-            <Text className="font-serif-bold text-4xl text-blue-800">epigram</Text>
-            <Text className="font-sans text-sm text-black-300">인생 명언을 모아보세요</Text>
+            <Text className="font-serif-bold text-4xl text-blue-800">
+              epigram
+            </Text>
+            <Text className="font-sans text-sm text-black-300">
+              인생 명언을 모아보세요
+            </Text>
           </View>
           <LoginForm />
           <View className="mt-3">
             <GuestLoginButton />
           </View>
           <View className="mt-6 flex-row justify-center gap-1">
-            <Text className="font-sans text-sm text-black-300">아직 회원이 아니신가요?</Text>
+            <Text className="font-sans text-sm text-black-300">
+              아직 회원이 아니신가요?
+            </Text>
             <Pressable onPress={handleGoToSignUp} accessibilityRole="link">
-              <Text className="font-sans text-sm font-semibold text-blue-600">회원가입</Text>
+              <Text className="font-sans text-sm font-semibold text-blue-600">
+                회원가입
+              </Text>
             </Pressable>
           </View>
         </ScrollView>

--- a/src/views/mypage/ui/MypageScreen.tsx
+++ b/src/views/mypage/ui/MypageScreen.tsx
@@ -1,4 +1,3 @@
-import { Redirect } from "expo-router";
 import { LogOut } from "lucide-react-native";
 import { type ReactElement } from "react";
 import { Pressable, ScrollView, Text, View } from "react-native";
@@ -33,8 +32,7 @@ export function MypageScreen(): ReactElement | null {
   const { user, isLoading } = useMe();
   const { handleLogout } = useLogout();
 
-  if (isLoading) return <LoadingState />;
-  if (!user) return <Redirect href="/login" />;
+  if (isLoading || !user) return <LoadingState />;
 
   return (
     <SafeAreaView className="flex-1 bg-background" edges={["top"]}>

--- a/src/views/signup/ui/SignUpScreen.tsx
+++ b/src/views/signup/ui/SignUpScreen.tsx
@@ -1,17 +1,18 @@
-import { Redirect, router } from "expo-router";
+import { router } from "expo-router";
 import type { ReactElement } from "react";
-import { KeyboardAvoidingView, Platform, Pressable, ScrollView, Text, View } from "react-native";
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-import { useMe } from "~/entities/user";
 import { SignUpForm } from "~/features/auth";
 
-export function SignUpScreen(): ReactElement | null {
-  const { user, isLoading } = useMe();
-
-  if (isLoading) return null;
-  if (user) return <Redirect href="/feeds" />;
-
+export function SignUpScreen(): ReactElement {
   function handleGoToLogin(): void {
     router.replace("/login");
   }
@@ -28,14 +29,20 @@ export function SignUpScreen(): ReactElement | null {
           keyboardShouldPersistTaps="handled"
         >
           <View className="mb-10 items-center gap-2">
-            <Text className="font-serif-bold text-4xl text-blue-800">epigram</Text>
+            <Text className="font-serif-bold text-4xl text-blue-800">
+              epigram
+            </Text>
             <Text className="font-sans text-sm text-black-300">회원가입</Text>
           </View>
           <SignUpForm />
           <View className="mt-6 flex-row justify-center gap-1">
-            <Text className="font-sans text-sm text-black-300">이미 회원이신가요?</Text>
+            <Text className="font-sans text-sm text-black-300">
+              이미 회원이신가요?
+            </Text>
             <Pressable onPress={handleGoToLogin} accessibilityRole="link">
-              <Text className="font-sans text-sm font-semibold text-blue-600">로그인</Text>
+              <Text className="font-sans text-sm font-semibold text-blue-600">
+                로그인
+              </Text>
             </Pressable>
           </View>
         </ScrollView>


### PR DESCRIPTION
Closes #99

## 주요 변경 사항

웹 `src/middleware.ts`와 동등한 라우트 보호 정책을 모바일에 도입.

- **`features/auth/model/authStore.ts`**: Zustand 스토어, `status: "unknown" | "authenticated" | "unauthenticated"` 3상태. `_layout.tsx`에서 부팅 시 SecureStore 토큰을 읽어 초기화.
- **`features/auth/ui/AuthGate.tsx`**: `mode="protected" | "auth-only"`로 라우트 가드. `unknown`은 LoadingState, protected는 미인증 시 `/login?redirect=<현재 경로>`로 리다이렉트, auth-only는 인증 시 `/feeds`로 리다이렉트.
- **라우트 적용**:
  - protected: `app/(tabs)/addepigram.tsx`, `app/(tabs)/mypage.tsx`, `app/epigrams/[id]/index.tsx`, `app/epigrams/[id]/edit.tsx`
  - auth-only: `app/login.tsx`, `app/signup.tsx`
- **로그인/회원가입/게스트 성공**: `setAuthenticated()` 호출 후 LoginForm은 `redirect` 쿼리 파라미터로 복귀(없으면 `/feeds`), 나머지는 `/feeds`.
- **세션 만료/로그아웃**: `setUnauthenticated()`가 SecureStore 토큰 정리 + 상태 갱신을 단일 책임으로 처리. `useSessionExpiryRedirect`도 동일 경로 사용.
- **인라인 guard 제거**: `MypageScreen`, `LoginScreen`, `SignUpScreen`, `AddEpigramScreen`, `EpigramDetailScreen`, `EpigramEditScreen`에서 `useMe` 기반 ad-hoc 리다이렉트 제거 — AuthGate가 단일 진실. 단, `EpigramEditScreen`의 글쓴이 본인 검증은 보호 정책과 별개라 유지.

## 테스트 방법

- [ ] 비로그인 상태로 `/addepigram`, `/mypage`, `/epigrams/<id>`, `/epigrams/<id>/edit` 접근 → `/login?redirect=<원래 경로>` 리다이렉트 확인
- [ ] 위 redirect 파라미터를 가진 로그인 화면에서 로그인 → 원래 경로로 복귀 확인
- [ ] redirect 파라미터 없이 로그인/회원가입/게스트 → `/feeds`로 이동 확인
- [ ] 로그인 상태로 `/login`, `/signup` 접근 → `/feeds`로 리다이렉트 확인
- [ ] 마이페이지에서 로그아웃 → `/login`으로 이동, 이후 보호 라우트 접근 시 다시 막힘
- [ ] (서버 401 시뮬레이션) 세션 만료 콜백 → `setUnauthenticated` + `/login` 이동

## 스크린샷

(로컬 실행 후 첨부)

## 참고

- 웹 미들웨어와 달리 모바일은 서버 미들웨어가 없어 클라이언트 라우트 가드(`AuthGate`)로 구현. SecureStore 비동기 read를 `unknown` 상태로 흡수.
- OAuth 카카오 로그인은 모바일에서 미구현 → 본 PR 범위 밖 (이슈 본문에 명시).
