### PR TITLE
fix: 마이페이지 댓글 목록 캐시 무효화 누락 + 댓글 카드 탭 영역 협소 (#101)

### DIFF
--- a/src/features/comment-create/model/useCommentCreate.ts
+++ b/src/features/comment-create/model/useCommentCreate.ts
@@ -3,6 +3,11 @@ import { useState } from "react";
 
 import { commentKeys, createComment } from "~/entities/comment";
 
+interface UseCommentCreateParams {
+  epigramId: number;
+  userId?: number;
+}
+
 interface UseCommentCreateReturn {
   content: string;
   isPrivate: boolean;
@@ -14,7 +19,10 @@ interface UseCommentCreateReturn {
   handleSubmit: () => void;
 }
 
-export function useCommentCreate(epigramId: number): UseCommentCreateReturn {
+export function useCommentCreate({
+  epigramId,
+  userId,
+}: UseCommentCreateParams): UseCommentCreateReturn {
   const queryClient = useQueryClient();
   const [content, setContent] = useState("");
   const [isPrivate, setIsPrivate] = useState(false);
@@ -30,6 +38,11 @@ export function useCommentCreate(epigramId: number): UseCommentCreateReturn {
       queryClient.invalidateQueries({
         queryKey: commentKeys.byEpigram(epigramId),
       });
+      if (userId !== undefined) {
+        queryClient.invalidateQueries({
+          queryKey: commentKeys.byUser(userId),
+        });
+      }
       setContent("");
       setIsPrivate(false);
     },

--- a/src/features/comment-create/ui/CommentForm.tsx
+++ b/src/features/comment-create/ui/CommentForm.tsx
@@ -13,6 +13,7 @@ interface CommentAuthor {
 interface CommentFormProps {
   epigramId: number;
   author: CommentAuthor | null;
+  userId?: number;
 }
 
 const MAX_LENGTH = 100;
@@ -24,6 +25,7 @@ const PLACEHOLDER_AUTHOR: CommentAuthor = {
 export function CommentForm({
   epigramId,
   author,
+  userId,
 }: CommentFormProps): ReactElement {
   const {
     content,
@@ -34,7 +36,7 @@ export function CommentForm({
     handleContentChange,
     handlePrivateToggle,
     handleSubmit,
-  } = useCommentCreate(epigramId);
+  } = useCommentCreate({ epigramId, userId });
 
   return (
     <View className="flex-row gap-3">

--- a/src/widgets/epigram-detail-list/ui/EpigramDetailList.tsx
+++ b/src/widgets/epigram-detail-list/ui/EpigramDetailList.tsx
@@ -21,6 +21,7 @@ interface SectionHeaderProps {
   totalCount: number | undefined;
   epigramId: number;
   author: { nickname: string; image: string | null } | null;
+  userId: number | undefined;
 }
 
 function ItemSeparator(): ReactElement {
@@ -57,6 +58,7 @@ function SectionHeader({
   totalCount,
   epigramId,
   author,
+  userId,
 }: SectionHeaderProps): ReactElement {
   return (
     <View className="gap-4 pt-2">
@@ -68,7 +70,7 @@ function SectionHeader({
           </Text>
         )}
       </View>
-      <CommentForm epigramId={epigramId} author={author} />
+      <CommentForm epigramId={epigramId} author={author} userId={userId} />
     </View>
   );
 }
@@ -115,10 +117,11 @@ export function EpigramDetailList({
           totalCount={totalCount}
           epigramId={epigramId}
           author={author}
+          userId={currentUserId}
         />
       </View>
     ),
-    [listHeader, totalCount, epigramId, author],
+    [listHeader, totalCount, epigramId, author, currentUserId],
   );
 
   const renderEmpty = useCallback((): ReactElement => {

--- a/src/widgets/mypage-activity/ui/MyCommentItem.tsx
+++ b/src/widgets/mypage-activity/ui/MyCommentItem.tsx
@@ -39,7 +39,12 @@ export function MyCommentItem({
   }
 
   return (
-    <View className="gap-3 border-t border-line-200 bg-background px-4 py-5 first:border-t-0">
+    <Pressable
+      onPress={handleCardPress}
+      accessibilityRole="button"
+      accessibilityLabel="에피그램으로 이동"
+      className="gap-3 border-t border-line-200 bg-background px-4 py-5 first:border-t-0"
+    >
       <View className="flex-row items-start gap-3">
         <UserAvatar
           image={comment.writer.image}
@@ -67,13 +72,11 @@ export function MyCommentItem({
             </Pressable>
           </View>
 
-          <Pressable onPress={handleCardPress} className="mt-2">
-            <Text className="font-sans text-sm leading-relaxed text-black-700">
-              {comment.content}
-            </Text>
-          </Pressable>
+          <Text className="mt-2 font-sans text-sm leading-relaxed text-black-700">
+            {comment.content}
+          </Text>
         </View>
       </View>
-    </View>
+    </Pressable>
   );
 }


### PR DESCRIPTION
## ✏️ 작업 내용

- `useCommentCreate`에 옵셔널 `userId` 파라미터 추가, 생성 성공 시 `commentKeys.byUser(userId)` invalidate
- `CommentForm` → `EpigramDetailList`에서 `me?.id`를 `userId`로 전달
- `MyCommentItem` 카드 최상위 View를 `Pressable`로 변경하여 카드 전체가 탭 영역이 되도록 수정

## 🗨️ 논의 사항 (참고 사항)

- 기존 `useCommentCreate`는 `byEpigram` 키만 invalidate하여 마이페이지의 `useMyComments`(`byUserList`)가 즉시 갱신되지 않던 버그. `useCommentDelete`는 이미 동일한 `byUser` invalidate 패턴을 가지고 있어 두 훅의 동작을 일관시킴.
- 카드 내부 삭제 버튼은 별도 `Pressable`로 유지되어 React Native responder system에 의해 탭 우선순위가 분리됨(부모 카드 탭이 트리거되지 않음).

## 기대효과

- 에피그램 상세에서 댓글을 새로 달면 마이페이지의 "내 댓글" 탭에 즉시 반영됨
- 마이페이지 댓글 카드 어디를 눌러도 해당 에피그램으로 이동

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
