### PR TITLE
fix: 마이페이지 프로필 이미지 카메라 배지가 원형 클립으로 잘림 (#103)

### DIFF
--- a/src/features/profile-image-upload/ui/ProfileImageUploadButton.tsx
+++ b/src/features/profile-image-upload/ui/ProfileImageUploadButton.tsx
@@ -28,7 +28,6 @@ export function ProfileImageUploadButton({
       onPress={() => {
         void pickAndUpload();
       }}
-      className="overflow-hidden rounded-full"
       style={{ width: AVATAR_SIZE, height: AVATAR_SIZE }}
     >
       <UserAvatar image={image} nickname={nickname} size={AVATAR_SIZE} />


### PR DESCRIPTION
## ✏️ 작업 내용

- `ProfileImageUploadButton` 외부 `Pressable`의 `overflow-hidden rounded-full` 제거

## 🗨️ 논의 사항 (참고 사항)

- `UserAvatar`가 자체적으로 `borderRadius`(이미지) / `rounded-full`(기본 아바타)로 원형 처리하므로 외부 컨테이너의 원형 클립이 불필요했음. 외부 클립으로 인해 우측 하단 카메라 배지의 모서리가 잘려 보이던 문제.

## 기대효과

- 마이페이지 프로필 사진 우측 하단의 카메라 배지가 잘리지 않고 온전히 표시됨

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)
