### PR TITLE
style: 마이페이지 감정 달력 셀 스타일 조정 (#105)

### DIFF
--- a/src/widgets/mypage-activity/ui/EmotionCalendar.tsx
+++ b/src/widgets/mypage-activity/ui/EmotionCalendar.tsx
@@ -106,7 +106,7 @@ interface DayCellProps {
 }
 
 function DayCell({ cell, emotion, isToday }: DayCellProps): ReactElement {
-  const borderClass = isToday ? "border-blue-500" : "border-line-200";
+  const borderClass = isToday ? "border-red-400 border-2" : "border-line-200";
   const bgClass = cell.isCurrentMonth ? "bg-white" : "bg-background/60";
   const dayTextClass = cell.isCurrentMonth ? "text-black-500" : "text-gray-200";
 
@@ -117,7 +117,9 @@ function DayCell({ cell, emotion, isToday }: DayCellProps): ReactElement {
     >
       {emotion ? (
         <>
-          <Text className="font-sans text-[10px] font-semibold text-gray-300">
+          <Text
+            className={`font-sans text-[12px] font-semibold ${dayTextClass}`}
+          >
             {cell.day}
           </Text>
           <Text style={{ fontSize: 18, marginTop: 2 }}>
@@ -210,7 +212,7 @@ export function EmotionCalendar({
         ))}
       </View>
 
-      <View className="flex-row flex-wrap">
+      <View className="flex-row flex-wrap border-line-200 border">
         {cells.map((cell, index) => (
           <View
             key={`${cell.dateKey}-${index}`}


### PR DESCRIPTION
## ✏️ 작업 내용

- 오늘 날짜 셀 테두리: `border-blue-500` → `border-red-400 border-2`로 강조
- 감정 기록 셀의 날짜 텍스트: `text-[10px] text-gray-300` → `text-[12px]` + `dayTextClass`로 당월/타월 색 구분
- 달력 그리드 컨테이너에 외곽선(`border-line-200 border`) 추가

## 🗨️ 논의 사항 (참고 사항)

- 사용자가 직접 손본 스타일 변경을 그대로 반영. 동작/로직 변경 없음.

## 기대효과

- 오늘 날짜 식별성 향상
- 감정 기록이 있는 셀의 날짜 가독성 향상
- 달력 영역 경계 명확화

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
