### PR TITLE
feat: 로그인·회원가입 화면 뒤로가기 버튼 + 로그아웃 후 피드로 이동 (#107)

### DIFF
--- a/src/features/auth/model/useLogout.ts
+++ b/src/features/auth/model/useLogout.ts
@@ -14,7 +14,7 @@ export function useLogout(): UseLogoutReturn {
   async function performLogout(): Promise<void> {
     await useAuthStore.getState().setUnauthenticated();
     queryClient.clear();
-    router.replace("/login");
+    router.replace("/feeds");
   }
 
   function handleLogout(): void {

--- a/src/views/login/ui/LoginScreen.tsx
+++ b/src/views/login/ui/LoginScreen.tsx
@@ -11,6 +11,7 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { GuestLoginButton, LoginForm } from "~/features/auth";
+import { HeaderBackButton } from "~/widgets/header";
 
 export function LoginScreen(): ReactElement {
   function handleGoToSignUp(): void {
@@ -18,7 +19,10 @@ export function LoginScreen(): ReactElement {
   }
 
   return (
-    <SafeAreaView className="flex-1 bg-background">
+    <SafeAreaView className="flex-1 bg-background" edges={["top"]}>
+      <View className="flex-row items-center px-screen-x py-2">
+        <HeaderBackButton />
+      </View>
       <KeyboardAvoidingView
         className="flex-1"
         behavior={Platform.OS === "ios" ? "padding" : undefined}

--- a/src/views/signup/ui/SignUpScreen.tsx
+++ b/src/views/signup/ui/SignUpScreen.tsx
@@ -11,6 +11,7 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { SignUpForm } from "~/features/auth";
+import { HeaderBackButton } from "~/widgets/header";
 
 export function SignUpScreen(): ReactElement {
   function handleGoToLogin(): void {
@@ -18,7 +19,10 @@ export function SignUpScreen(): ReactElement {
   }
 
   return (
-    <SafeAreaView className="flex-1 bg-background">
+    <SafeAreaView className="flex-1 bg-background" edges={["top"]}>
+      <View className="flex-row items-center px-screen-x py-2">
+        <HeaderBackButton />
+      </View>
       <KeyboardAvoidingView
         className="flex-1"
         behavior={Platform.OS === "ios" ? "padding" : undefined}


### PR DESCRIPTION
## ✏️ 작업 내용

- `LoginScreen`, `SignUpScreen` 상단에 `HeaderBackButton` 추가
- `useLogout`의 로그아웃 후 리다이렉트 경로를 `/login` → `/feeds`로 변경

## 🗨️ 논의 사항 (참고 사항)

- `HeaderBackButton`은 `router.canGoBack()` 시 뒤로, 아니면 `/feeds`로 fallback. 보호 경로에서 리다이렉트로 들어온 사용자도 자연스럽게 피드로 복귀 가능.
- 게스트 모드 진입 후 다시 로그인하지 않고 사용 중인 사용자가 로그아웃하면 즉시 같은 피드 화면을 계속 사용할 수 있도록 일관된 경로로 통일.

## 기대효과

- 비로그인 사용자가 로그인/회원가입 화면에서 막히지 않고 피드로 돌아갈 수 있음
- 로그아웃이 게스트 모드와 동일한 사용자 흐름으로 이어짐

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)
