### PR TITLE
feat: 피드 페이지 상단에 감정 선택 카드 추가 (#109)

### DIFF
--- a/src/widgets/epigram-feed/ui/EpigramFeed.tsx
+++ b/src/widgets/epigram-feed/ui/EpigramFeed.tsx
@@ -13,11 +13,20 @@ import {
   useEpigrams,
   type Epigram,
 } from "~/entities/epigram";
+import { EmotionSelector } from "~/features/emotion-select";
 
 const FEED_PAGE_SIZE = 10;
 
 function ItemSeparator(): ReactElement {
   return <View className="h-6" />;
+}
+
+function ListHeader(): ReactElement {
+  return (
+    <View className="mb-6">
+      <EmotionSelector />
+    </View>
+  );
 }
 
 function LoadingState(): ReactElement {
@@ -91,6 +100,7 @@ export function EpigramFeed(): ReactElement {
       keyExtractor={(item) => String(item.id)}
       renderItem={renderItem}
       ItemSeparatorComponent={ItemSeparator}
+      ListHeaderComponent={ListHeader}
       ListEmptyComponent={EmptyState}
       ListFooterComponent={<FooterLoader visible={isFetchingNextPage} />}
       onEndReached={handleEndReached}


### PR DESCRIPTION
## ✏️ 작업 내용

- `EpigramFeed`의 `FlatList` `ListHeaderComponent`로 `EmotionSelector` 삽입
- 헤더 하단에 `mb-6`을 적용해 카드 목록과 시각적으로 분리

## 🗨️ 논의 사항 (참고 사항)

- `EmotionSelector`는 `~/features/emotion-select`에서 이미 재사용 가능한 형태로 export되어 있어 추가 로직 없이 바로 조립 가능.
- 피드가 로딩/에러 상태일 때는 헤더도 함께 노출되지 않도록 기존 early return 흐름을 그대로 유지.

## 기대효과

- 피드 진입 시점에 오늘의 감정을 즉시 기록 가능 — 마이페이지로의 이동 불필요
- 감정 기록 기능 노출 증가

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)