### PR TITLE
fix: 비로그인 상태에서 피드/로그아웃 시 로그인 페이지로 무한 리다이렉트 (#111)

### DIFF
--- a/src/entities/user/api/user.ts
+++ b/src/entities/user/api/user.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "~/shared/api/client";
+import { getAccessToken, getRefreshToken } from "~/shared/api/tokenStorage";
 
 import { userSchema, type User } from "../model/schema";
 
@@ -8,6 +9,12 @@ export interface UpdateMeBody {
 }
 
 export async function getMe(): Promise<User | null> {
+  const [access, refresh] = await Promise.all([
+    getAccessToken(),
+    getRefreshToken(),
+  ]);
+  if (!access && !refresh) return null;
+
   const response = await apiClient.get<User | null>("/users/me");
   if (response.data === null) return null;
   return userSchema.parse(response.data);

--- a/src/widgets/epigram-feed/ui/EpigramFeed.tsx
+++ b/src/widgets/epigram-feed/ui/EpigramFeed.tsx
@@ -13,6 +13,7 @@ import {
   useEpigrams,
   type Epigram,
 } from "~/entities/epigram";
+import { useAuthStore } from "~/features/auth";
 import { EmotionSelector } from "~/features/emotion-select";
 
 const FEED_PAGE_SIZE = 10;
@@ -68,6 +69,7 @@ function FooterLoader({ visible }: { visible: boolean }): ReactElement | null {
 }
 
 export function EpigramFeed(): ReactElement {
+  const isAuthenticated = useAuthStore((s) => s.status === "authenticated");
   const {
     data,
     isLoading,
@@ -100,7 +102,7 @@ export function EpigramFeed(): ReactElement {
       keyExtractor={(item) => String(item.id)}
       renderItem={renderItem}
       ItemSeparatorComponent={ItemSeparator}
-      ListHeaderComponent={ListHeader}
+      ListHeaderComponent={isAuthenticated ? ListHeader : null}
       ListEmptyComponent={EmptyState}
       ListFooterComponent={<FooterLoader visible={isFetchingNextPage} />}
       onEndReached={handleEndReached}


### PR DESCRIPTION
## ✏️ 작업 내용

- `getMe()`: 토큰이 하나도 없으면 네트워크 호출 없이 `null` 반환 — 게스트 사용자가 `/users/me`를 호출해 401을 받고 `onSessionExpired()`가 발동하는 루프를 원천 차단
- `EpigramFeed`: `ListHeaderComponent`를 `status === "authenticated"`일 때만 `EmotionSelector`로 렌더링, 그 외엔 `null`

## 🗨️ 논의 사항 (참고 사항)

- 증상: (1) 게스트 상태로 피드 진입 시 즉시 `/login`으로 튕김 (2) 로그아웃 후 `/feeds`로 replace해도 피드 마운트 시 다시 `/login`으로 튕김
- 원인: `EmotionSelector` → `useEmotionSelect` → `useMe()`가 무조건 `GET /users/me` → 401 → refresh 실패 → `router.replace("/login")`
- 게스트가 이모션 버튼을 눌러도 `postTodayEmotion`이 401을 받으면서 동일한 흐름을 탈 수 있으나, 버튼 자체를 노출하지 않도록 헤더를 조건부로 숨겨 문제 원천 제거

## 기대효과

- 게스트 모드에서 피드 정상 조회
- 로그아웃 후 피드로 정상 복귀

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)