### PR TITLE
chore: ErrorBoundary 도입 (#113)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -8,7 +8,9 @@ import { useFonts } from "expo-font";
 import { Stack } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
-import { useEffect } from "react";
+import { AlertTriangle } from "lucide-react-native";
+import { useEffect, type ReactElement } from "react";
+import { Pressable, SafeAreaView, Text, View } from "react-native";
 import "react-native-reanimated";
 
 import { useAuthStore, useSessionExpiryRedirect } from "~/features/auth";
@@ -19,6 +21,40 @@ SplashScreen.preventAutoHideAsync();
 export const unstable_settings = {
   anchor: "(tabs)",
 };
+
+interface RouteErrorBoundaryProps {
+  error: Error;
+  retry: () => Promise<void>;
+}
+
+export function ErrorBoundary({
+  error,
+  retry,
+}: RouteErrorBoundaryProps): ReactElement {
+  return (
+    <SafeAreaView className="flex-1 bg-background">
+      <View className="flex-1 items-center justify-center gap-4 px-6">
+        <AlertTriangle size={32} color="#f87171" strokeWidth={1.5} />
+        <Text className="font-serif text-xl text-black-700">
+          화면을 표시하지 못했습니다
+        </Text>
+        <Text className="text-center font-sans text-sm text-black-500">
+          {error.message}
+        </Text>
+        <Pressable
+          onPress={() => {
+            void retry();
+          }}
+          accessibilityRole="button"
+          accessibilityLabel="다시 시도"
+          className="mt-2 rounded-full border border-blue-500 px-6 py-2"
+        >
+          <Text className="font-sans text-sm text-blue-500">다시 시도</Text>
+        </Pressable>
+      </View>
+    </SafeAreaView>
+  );
+}
 
 export default function RootLayout() {
   const [fontsLoaded, fontsError] = useFonts({

--- a/src/shared/ui/ErrorBoundary.tsx
+++ b/src/shared/ui/ErrorBoundary.tsx
@@ -1,0 +1,43 @@
+import { Component } from "react";
+import type { ErrorInfo, ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  fallback: ReactNode | ((error: Error, reset: () => void) => ReactNode);
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error("[ErrorBoundary]", error, info.componentStack);
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    const { error } = this.state;
+    const { fallback, children } = this.props;
+
+    if (error !== null) {
+      return typeof fallback === "function"
+        ? fallback(error, this.reset)
+        : fallback;
+    }
+
+    return children;
+  }
+}

--- a/src/shared/ui/SectionErrorFallback.tsx
+++ b/src/shared/ui/SectionErrorFallback.tsx
@@ -1,0 +1,29 @@
+import { AlertTriangle } from "lucide-react-native";
+import { type ReactElement } from "react";
+import { Pressable, Text, View } from "react-native";
+
+interface SectionErrorFallbackProps {
+  reset: () => void;
+}
+
+export function SectionErrorFallback({
+  reset,
+}: SectionErrorFallbackProps): ReactElement {
+  return (
+    <View className="items-center gap-3 rounded-2xl border border-red-100 bg-red-50 py-10">
+      <AlertTriangle size={20} color="#f87171" strokeWidth={1.5} />
+      <Text className="font-sans text-sm font-medium text-error">
+        불러오지 못했습니다
+      </Text>
+      <Pressable
+        onPress={reset}
+        accessibilityRole="button"
+        accessibilityLabel="다시 시도"
+      >
+        <Text className="font-sans text-xs text-black-400 underline">
+          다시 시도
+        </Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,8 +1,10 @@
 export { Button } from "./Button";
 export type { ButtonProps } from "./Button";
+export { ErrorBoundary } from "./ErrorBoundary";
 export { ErrorState } from "./ErrorState";
 export { Input } from "./Input";
 export type { InputProps } from "./Input";
 export { LoadingState } from "./LoadingState";
 export { PrivacyToggle } from "./PrivacyToggle";
+export { SectionErrorFallback } from "./SectionErrorFallback";
 export { UserAvatar } from "./UserAvatar";

--- a/src/widgets/epigram-feed/ui/EpigramFeed.tsx
+++ b/src/widgets/epigram-feed/ui/EpigramFeed.tsx
@@ -15,6 +15,7 @@ import {
 } from "~/entities/epigram";
 import { useAuthStore } from "~/features/auth";
 import { EmotionSelector } from "~/features/emotion-select";
+import { ErrorBoundary, SectionErrorFallback } from "~/shared/ui";
 
 const FEED_PAGE_SIZE = 10;
 
@@ -69,6 +70,16 @@ function FooterLoader({ visible }: { visible: boolean }): ReactElement | null {
 }
 
 export function EpigramFeed(): ReactElement {
+  return (
+    <ErrorBoundary
+      fallback={(_, reset) => <SectionErrorFallback reset={reset} />}
+    >
+      <EpigramFeedInner />
+    </ErrorBoundary>
+  );
+}
+
+function EpigramFeedInner(): ReactElement {
   const isAuthenticated = useAuthStore((s) => s.status === "authenticated");
   const {
     data,

--- a/src/widgets/mypage-activity/ui/MypageActivity.tsx
+++ b/src/widgets/mypage-activity/ui/MypageActivity.tsx
@@ -1,6 +1,8 @@
 import { type ReactElement } from "react";
 import { View } from "react-native";
 
+import { ErrorBoundary, SectionErrorFallback } from "~/shared/ui";
+
 import { EmotionCalendar } from "./EmotionCalendar";
 import { EmotionPieChart } from "./EmotionPieChart";
 import { TabbedSection } from "./TabbedSection";
@@ -12,9 +14,21 @@ interface MypageActivityProps {
 export function MypageActivity({ userId }: MypageActivityProps): ReactElement {
   return (
     <View className="gap-4">
-      <EmotionCalendar userId={userId} />
-      <EmotionPieChart userId={userId} />
-      <TabbedSection userId={userId} />
+      <ErrorBoundary
+        fallback={(_, reset) => <SectionErrorFallback reset={reset} />}
+      >
+        <EmotionCalendar userId={userId} />
+      </ErrorBoundary>
+      <ErrorBoundary
+        fallback={(_, reset) => <SectionErrorFallback reset={reset} />}
+      >
+        <EmotionPieChart userId={userId} />
+      </ErrorBoundary>
+      <ErrorBoundary
+        fallback={(_, reset) => <SectionErrorFallback reset={reset} />}
+      >
+        <TabbedSection userId={userId} />
+      </ErrorBoundary>
     </View>
   );
 }


### PR DESCRIPTION
## ✏️ 작업 내용

웹 프로젝트의 선언적 에러 처리 패턴을 모바일에 그대로 포팅했습니다.

- `src/shared/ui/ErrorBoundary.tsx` — class component 기반 범용 바운더리 (fallback을 ReactNode 또는 `(error, reset) => ReactNode` 형태로 받음)
- `src/shared/ui/SectionErrorFallback.tsx` — 섹션 내 공용 에러 fallback UI (lucide-react-native `AlertTriangle` + "다시 시도" Pressable)
- `src/widgets/epigram-feed/ui/EpigramFeed.tsx` — 외곽 `EpigramFeed` 컴포넌트에서 ErrorBoundary로 감싸고, 훅을 쓰는 본체를 `EpigramFeedInner`로 분리
- `src/widgets/mypage-activity/ui/MypageActivity.tsx` — EmotionCalendar / EmotionPieChart / TabbedSection 세 섹션을 각각 개별 ErrorBoundary로 래핑 (한 섹션 실패가 나머지를 막지 않도록)
- `app/_layout.tsx` — expo-router 라우트 레벨 `ErrorBoundary` named export 추가 (루트 렌더 에러 캐치)

## 🗨️ 논의 사항 (참고 사항)

- 웹 `src/shared/ui/ErrorBoundary.tsx`, `SectionErrorFallback.tsx` 와 동일한 인터페이스를 유지하여 팀 내 인지 부하를 줄였습니다.
- RN은 DOM이 없으므로 `div/button/p` → `View/Text/Pressable` 로 치환했고, `lucide-react` → `lucide-react-native` 로 교체했습니다.
- MypageActivity 는 각 섹션이 독립된 데이터에 의존하므로 섹션별 바운더리를, EpigramFeed 는 전체가 하나의 피드라 외곽 바운더리 1개로 적용했습니다.

## 기대효과

- 한 위젯에서 발생한 런타임 에러가 전체 페이지를 흰 화면으로 만들지 않습니다.
- 사용자는 "다시 시도" 버튼으로 해당 섹션만 리셋할 수 있습니다.
- 루트 레벨 렌더 에러도 expo-router ErrorBoundary 로 캐치되어 크래시 대신 안내 화면이 표시됩니다.

Closes #113