### PR TITLE
feat: 피드 상단에 오늘의 에피그램 섹션 추가 (#115)

### DIFF
--- a/src/widgets/epigram-feed/ui/EpigramFeed.tsx
+++ b/src/widgets/epigram-feed/ui/EpigramFeed.tsx
@@ -11,6 +11,7 @@ import {
   EpigramCard,
   navigateToEpigram,
   useEpigrams,
+  useTodayEpigram,
   type Epigram,
 } from "~/entities/epigram";
 import { useAuthStore } from "~/features/auth";
@@ -23,10 +24,62 @@ function ItemSeparator(): ReactElement {
   return <View className="h-6" />;
 }
 
-function ListHeader(): ReactElement {
+function SectionHeading({ label }: { label: string }): ReactElement {
   return (
-    <View className="mb-6">
-      <EmotionSelector />
+    <Text className="mb-4 font-serif text-xl font-bold text-black-700">
+      {label}
+    </Text>
+  );
+}
+
+function TodayEpigramLoading(): ReactElement {
+  return <View className="h-32 rounded-2xl bg-blue-200" />;
+}
+
+function TodayEpigramEmpty(): ReactElement {
+  return (
+    <View className="items-center gap-2 rounded-2xl border border-line-200 bg-surface px-6 py-8">
+      <Text className="font-serif text-base text-black-400">
+        오늘의 에피그램이 아직 작성되지 않았습니다
+      </Text>
+      <Text className="font-serif text-xs text-blue-400">
+        — 좋은 글귀가 곧 채워질 거예요
+      </Text>
+    </View>
+  );
+}
+
+function TodayEpigramBody(): ReactElement {
+  const { data: todayEpigram, isLoading } = useTodayEpigram();
+
+  if (isLoading) return <TodayEpigramLoading />;
+  if (!todayEpigram) return <TodayEpigramEmpty />;
+  return <EpigramCard epigram={todayEpigram} onPress={navigateToEpigram} />;
+}
+
+function TodayEpigramSection(): ReactElement {
+  return (
+    <View>
+      <SectionHeading label="오늘의 에피그램" />
+      <TodayEpigramBody />
+    </View>
+  );
+}
+
+function ListHeader({
+  showEmotionSelector,
+}: {
+  showEmotionSelector: boolean;
+}): ReactElement {
+  return (
+    <View className="mb-6 gap-10">
+      {showEmotionSelector && <EmotionSelector />}
+      <ErrorBoundary
+        fallback={(_, reset) => <SectionErrorFallback reset={reset} />}
+      >
+        <TodayEpigramSection />
+      </ErrorBoundary>
+      <SectionHeading label="최신 에피그램" />
     </View>
   );
 }
@@ -113,7 +166,7 @@ function EpigramFeedInner(): ReactElement {
       keyExtractor={(item) => String(item.id)}
       renderItem={renderItem}
       ItemSeparatorComponent={ItemSeparator}
-      ListHeaderComponent={isAuthenticated ? ListHeader : null}
+      ListHeaderComponent={<ListHeader showEmotionSelector={isAuthenticated} />}
       ListEmptyComponent={EmptyState}
       ListFooterComponent={<FooterLoader visible={isFetchingNextPage} />}
       onEndReached={handleEndReached}


### PR DESCRIPTION
## ✏️ 작업 내용

웹 `/epigrams` 와 동일하게 피드 최상단에 **"오늘의 에피그램"** 섹션을 추가하고 그 아래 **"최신 에피그램"** 리스트를 렌더링합니다.

- `widgets/epigram-feed/ui/EpigramFeed.tsx`
  - `TodayEpigramSection`, `TodayEpigramBody`, `TodayEpigramEmpty`, `TodayEpigramLoading` 추가
  - `useTodayEpigram`(공개 API)로 데이터 패칭, `EpigramCard` 재사용
  - FlatList `ListHeaderComponent`에 `오늘의 에피그램` → `최신 에피그램` 순서로 배치
  - `EmotionSelector` 는 로그인 사용자에게만 노출(기존 동작 유지)
  - `TodayEpigramSection` 은 섹션별 `ErrorBoundary` 로 감쌈 → 오늘의 에피그램이 실패해도 피드 자체는 살아남음

## 🗨️ 논의 사항 (참고 사항)

- `useTodayEpigram` 과 `EpigramCard` 는 이미 `entities/epigram` 에 존재하므로 엔티티 추가 없이 조합만 했습니다.
- 웹 버전의 장식용 따옴표(`"`)는 모바일 디자인에 과해 보여, 기본 카드 형태와 중앙 정렬 빈 상태 텍스트로만 단순화했습니다.
- 섹션 헤딩(`오늘의/최신 에피그램`)은 공용 로컬 컴포넌트 `SectionHeading` 으로 통일했습니다.

## 기대효과

- 웹/모바일 피드 정보 구조가 일치해 크로스 플랫폼 사용자 경험이 통일됩니다.
- 오늘의 에피그램이 하나의 응집된 섹션으로 노출되어 발견성이 높아집니다.

Closes #115