### PR TITLE
fix: 에피그램 수정 후 뒤로가기 시 상세 화면 중복 노출 수정

### DIFF
--- a/src/features/epigram-edit/model/useEpigramEdit.ts
+++ b/src/features/epigram-edit/model/useEpigramEdit.ts
@@ -57,6 +57,10 @@ export function useEpigramEdit(epigramId: number): UseEpigramEditReturn {
       queryClient.invalidateQueries({
         queryKey: epigramKeys.detail(epigramId),
       });
+      if (router.canGoBack()) {
+        router.back();
+        return;
+      }
       router.replace(`/epigrams/${epigram.id}`);
     },
   });


### PR DESCRIPTION
## Summary

- 에피그램 수정 완료 시 `router.replace` 가 동일한 상세 경로로 스택을 덮어써 `Detail → Detail` 중복이 발생하던 문제를 해결
- `router.canGoBack()` 이면 `router.back()` 으로 기존 Detail 로 복귀, 아니면 기존처럼 `replace` 로 이동 (딥링크 케이스 보존)
- `handleCancel` 과 동일한 복귀 패턴으로 일관성 확보

TanStack Query `invalidateQueries` 로 Detail 이 최신 데이터로 재렌더링되므로, 스택을 한 단계 줄여도 UX 는 동일합니다.

Closes #117

## Test plan

- [ ] 목록 → 상세 → 수정 → 수정 완료 → 뒤로가기 시 목록으로 복귀되는지 확인
- [ ] 수정된 내용이 복귀한 상세 화면에 즉시 반영되는지 확인
- [ ] 취소 버튼 동작도 기존과 동일한지 회귀 확인
- [ ] (선택) 딥링크로 Edit 직접 진입 후 수정 완료 시 상세로 정상 이동하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)