### PR TITLE
fix: 로그아웃 시 /login 으로 튕기는 경쟁 조건 수정

### DIFF
--- a/src/features/auth/model/useLogout.ts
+++ b/src/features/auth/model/useLogout.ts
@@ -12,9 +12,9 @@ export function useLogout(): UseLogoutReturn {
   const queryClient = useQueryClient();
 
   async function performLogout(): Promise<void> {
+    router.replace("/feeds");
     await clearTokens();
     queryClient.clear();
-    router.replace("/feeds");
   }
 
   function handleLogout(): void {

--- a/src/features/auth/ui/AuthGate.tsx
+++ b/src/features/auth/ui/AuthGate.tsx
@@ -1,3 +1,4 @@
+import { useIsFocused } from "@react-navigation/native";
 import { Redirect, usePathname } from "expo-router";
 import type { ReactElement, ReactNode } from "react";
 
@@ -11,18 +12,21 @@ interface AuthGateProps {
   children: ReactNode;
 }
 
-export function AuthGate({ mode, children }: AuthGateProps): ReactElement {
+export function AuthGate({ mode, children }: AuthGateProps): ReactElement | null {
   const { user, isLoading } = useMe();
   const pathname = usePathname();
+  const isFocused = useIsFocused();
 
   if (isLoading) return <LoadingState />;
 
   if (mode === "protected" && !user) {
+    if (!isFocused) return null;
     const redirectParam = encodeURIComponent(pathname);
     return <Redirect href={`/login?redirect=${redirectParam}`} />;
   }
 
   if (mode === "auth-only" && user) {
+    if (!isFocused) return null;
     return <Redirect href="/feeds" />;
   }
 


### PR DESCRIPTION
## Summary

마이페이지에서 로그아웃하면 `/feeds` 로 이동해야 하는데 `/login?redirect=/mypage` 으로 튕기던 버그를 수정합니다. 원인은 두 개가 맞물린 경쟁 조건이었고, 둘 다 방어합니다.

### A. `AuthGate` 를 포커스 인식형으로
- `@react-navigation/native` 의 `useIsFocused` 를 추가
- 현재 라우트가 포커스돼 있지 않으면 `<Redirect>` 를 렌더하지 않고 `null` 반환
- 탭 네비게이터는 이전 탭을 언마운트하지 않으므로, 백그라운드 탭에서 인증 상태가 바뀌어도 Redirect 가 튀지 않음
- 탭이 다시 포커스되면 AuthGate 가 재렌더링돼 정상적으로 `/login` 으로 유도

### B. `performLogout` 실행 순서 반전
```ts
router.replace("/feeds");   // 1) 먼저 포커스 이동
await clearTokens();        // microtask 경계
queryClient.clear();        // 2) 이미 언포커스 된 뒤 cache clear
```

`await` 가 microtask 경계를 만들어 navigation 커밋 시간을 확보합니다. `useMe()` 가 null 로 바뀔 때쯤엔 `/mypage` 는 이미 언포커스 상태라 Redirect 조건이 성립하지 않음.

A 만으로는 React 18 배칭 타이밍에 의존적이고, B 만으로는 나중에 마이 탭을 다시 눌렀을 때 가드가 없습니다. 두 방어를 모두 적용해야 구멍이 닫힙니다.

Closes #119

## Test plan

- [ ] 로그인 → 마이페이지 → 로그아웃 → `/feeds` 로 이동 확인
- [ ] 로그아웃 후 마이 탭 재탭 시 `/login?redirect=/mypage` 으로 유도되는지 확인
- [ ] 비로그인 상태에서 딥링크로 `/epigrams/[id]/edit` 진입 시 기존대로 `/login?redirect=...` 유지되는지 확인
- [ ] 로그인 상태에서 `/login` 접근 시 `/feeds` 로 리다이렉트 유지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)