### PR TITLE
feat: 감정 캘린더에 감정 필터 추가

### DIFF
--- a/src/widgets/mypage-activity/ui/EmotionCalendar.tsx
+++ b/src/widgets/mypage-activity/ui/EmotionCalendar.tsx
@@ -1,9 +1,10 @@
 import { ChevronLeft, ChevronRight } from "lucide-react-native";
 import { useMemo, useState, type ReactElement } from "react";
-import { Pressable, Text, View } from "react-native";
+import { Pressable, ScrollView, Text, View } from "react-native";
 
 import {
   EMOTION_META,
+  EMOTION_ORDER,
   useMonthlyEmotions,
   type Emotion,
 } from "~/entities/emotion-log";
@@ -99,6 +100,82 @@ function MonthHeader({
   );
 }
 
+type EmotionFilter = Emotion | null;
+
+interface EmotionFilterBarProps {
+  selected: EmotionFilter;
+  onSelect: (next: EmotionFilter) => void;
+}
+
+interface FilterChipProps {
+  isActive: boolean;
+  onPress: () => void;
+  label: string;
+  emoji?: string;
+}
+
+function FilterChip({
+  isActive,
+  onPress,
+  label,
+  emoji,
+}: FilterChipProps): ReactElement {
+  const containerClass = isActive
+    ? "bg-blue-100 border-blue-300"
+    : "bg-background border-line-200";
+  const labelClass = isActive
+    ? "font-semibold text-black-700"
+    : "font-medium text-black-300";
+
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`${label} 필터`}
+      accessibilityState={{ selected: isActive }}
+      className={`flex-row items-center gap-1 rounded-full border px-3 py-1.5 ${containerClass}`}
+    >
+      {emoji ? <Text style={{ fontSize: 14 }}>{emoji}</Text> : null}
+      <Text className={`font-sans text-xs ${labelClass}`}>{label}</Text>
+    </Pressable>
+  );
+}
+
+function EmotionFilterBar({
+  selected,
+  onSelect,
+}: EmotionFilterBarProps): ReactElement {
+  function handleSelect(next: Emotion): void {
+    onSelect(selected === next ? null : next);
+  }
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerClassName="gap-2 pb-3"
+    >
+      <FilterChip
+        isActive={selected === null}
+        onPress={() => onSelect(null)}
+        label="전체"
+      />
+      {EMOTION_ORDER.map((emotion) => {
+        const meta = EMOTION_META[emotion];
+        return (
+          <FilterChip
+            key={emotion}
+            isActive={selected === emotion}
+            onPress={() => handleSelect(emotion)}
+            label={meta.label}
+            emoji={meta.emoji}
+          />
+        );
+      })}
+    </ScrollView>
+  );
+}
+
 interface DayCellProps {
   cell: CalendarCell;
   emotion: Emotion | undefined;
@@ -149,6 +226,7 @@ export function EmotionCalendar({
 
   const [year, setYear] = useState(todayYear);
   const [month, setMonth] = useState(todayMonth);
+  const [filter, setFilter] = useState<EmotionFilter>(null);
 
   const { data: emotionLogs = [] } = useMonthlyEmotions({
     userId,
@@ -202,6 +280,8 @@ export function EmotionCalendar({
         onNext={handleNextMonth}
       />
 
+      <EmotionFilterBar selected={filter} onSelect={setFilter} />
+
       <View className="flex-row">
         {WEEKDAY_LABELS.map((label) => (
           <View key={label} className="flex-1 items-center py-2">
@@ -213,18 +293,23 @@ export function EmotionCalendar({
       </View>
 
       <View className="flex-row flex-wrap border-line-200 border">
-        {cells.map((cell, index) => (
-          <View
-            key={`${cell.dateKey}-${index}`}
-            style={{ width: `${100 / 7}%` }}
-          >
-            <DayCell
-              cell={cell}
-              emotion={emotionByDate.get(cell.dateKey)}
-              isToday={isCellToday(cell)}
-            />
-          </View>
-        ))}
+        {cells.map((cell, index) => {
+          const dayEmotion = emotionByDate.get(cell.dateKey);
+          const visibleEmotion =
+            filter === null || dayEmotion === filter ? dayEmotion : undefined;
+          return (
+            <View
+              key={`${cell.dateKey}-${index}`}
+              style={{ width: `${100 / 7}%` }}
+            >
+              <DayCell
+                cell={cell}
+                emotion={visibleEmotion}
+                isToday={isCellToday(cell)}
+              />
+            </View>
+          );
+        })}
       </View>
     </View>
   );


### PR DESCRIPTION
## Summary

웹 버전에만 있던 감정 캘린더 필터를 모바일에 포팅합니다.

- 월 헤더 아래 가로 스크롤 감정 칩 바 추가 (`전체` + `EMOTION_ORDER` 5개)
- 칩 선택 시 해당 감정이 기록된 날만 이모지 표시, 나머지는 숫자만 렌더
- 같은 칩 재선택 시 토글 해제 → `전체` 로 복귀
- `useMonthlyEmotions` 재호출 없이 **클라이언트 렌더 단계에서만 필터링** 하여 불필요한 네트워크 호출 제거
- 활성 상태 색상은 기존 `EmotionSelector` 와 동일한 `bg-blue-100 border-blue-300` 으로 통일

Closes #121

## Test plan

- [ ] 마이페이지 진입 → 캘린더 상단 칩 바 표시 확인
- [ ] 특정 감정 선택 시 해당 감정 날짜만 이모지로 남고 나머지는 숫자만 보이는지 확인
- [ ] 같은 칩 재선택 시 전체 복귀되는지 확인
- [ ] 월 이동(이전/다음) 후에도 필터 상태 유지되는지 확인
- [ ] 필터 전환 시 네트워크 요청이 발생하지 않는지 확인 (React Query Devtools 또는 네트워크 로그)

🤖 Generated with [Claude Code](https://claude.com/claude-code)