### PR TITLE
fix: 댓글 수정 시 키보드에 입력창이 가려지는 문제 해결

### DIFF
--- a/src/widgets/epigram-detail-list/ui/CommentItem.tsx
+++ b/src/widgets/epigram-detail-list/ui/CommentItem.tsx
@@ -12,12 +12,16 @@ interface CommentItemProps {
   comment: Comment;
   epigramId: number;
   currentUserId: number | undefined;
+  index: number;
+  onStartEdit: (index: number) => void;
 }
 
 function CommentItemBase({
   comment,
   epigramId,
   currentUserId,
+  index,
+  onStartEdit,
 }: CommentItemProps): ReactElement {
   const [isEditing, setIsEditing] = useState(false);
   const { deleteComment } = useCommentDelete({
@@ -28,12 +32,17 @@ function CommentItemBase({
   const isOwnComment =
     currentUserId !== undefined && comment.writer.id === currentUserId;
 
+  function handleStartEdit(): void {
+    setIsEditing(true);
+    onStartEdit(index);
+  }
+
   function handleOpenMenu(): void {
     Alert.alert(
       "댓글",
       undefined,
       [
-        { text: "수정", onPress: () => setIsEditing(true) },
+        { text: "수정", onPress: handleStartEdit },
         { text: "삭제", style: "destructive", onPress: deleteComment },
         { text: "취소", style: "cancel" },
       ],

--- a/src/widgets/epigram-detail-list/ui/EpigramDetailList.tsx
+++ b/src/widgets/epigram-detail-list/ui/EpigramDetailList.tsx
@@ -1,5 +1,5 @@
 import { MessageCircle } from "lucide-react-native";
-import { useCallback, useMemo, type ReactElement } from "react";
+import { useCallback, useMemo, useRef, type ReactElement } from "react";
 import { ActivityIndicator, FlatList, Text, View } from "react-native";
 
 import { useEpigramComments, type Comment } from "~/entities/comment";
@@ -80,6 +80,7 @@ export function EpigramDetailList({
   listHeader,
 }: EpigramDetailListProps): ReactElement {
   const { user: me } = useMe();
+  const listRef = useRef<FlatList<Comment>>(null);
   const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
     useEpigramComments({ epigramId, limit: COMMENTS_PAGE_SIZE });
 
@@ -98,15 +99,35 @@ export function EpigramDetailList({
     if (hasNextPage && !isFetchingNextPage) fetchNextPage();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
+  const handleStartEdit = useCallback((index: number): void => {
+    listRef.current?.scrollToIndex({
+      index,
+      viewPosition: 0,
+      animated: true,
+    });
+  }, []);
+
+  const handleScrollToIndexFailed = useCallback(
+    (info: { index: number; averageItemLength: number }): void => {
+      listRef.current?.scrollToOffset({
+        offset: info.averageItemLength * info.index,
+        animated: true,
+      });
+    },
+    [],
+  );
+
   const renderItem = useCallback(
-    ({ item }: { item: Comment }) => (
+    ({ item, index }: { item: Comment; index: number }) => (
       <CommentItem
         comment={item}
         epigramId={epigramId}
         currentUserId={currentUserId}
+        index={index}
+        onStartEdit={handleStartEdit}
       />
     ),
-    [epigramId, currentUserId],
+    [epigramId, currentUserId, handleStartEdit],
   );
 
   const headerElement = useMemo(
@@ -149,6 +170,7 @@ export function EpigramDetailList({
 
   return (
     <FlatList
+      ref={listRef}
       data={comments}
       keyExtractor={(comment) => String(comment.id)}
       renderItem={renderItem}
@@ -161,6 +183,8 @@ export function EpigramDetailList({
       ItemSeparatorComponent={ItemSeparator}
       ListHeaderComponentStyle={{ marginBottom: 12 }}
       keyboardShouldPersistTaps="handled"
+      automaticallyAdjustKeyboardInsets
+      onScrollToIndexFailed={handleScrollToIndexFailed}
     />
   );
 }


### PR DESCRIPTION
## Summary
- `EpigramDetailList`의 `FlatList`에 `ref`와 `automaticallyAdjustKeyboardInsets` 추가
- 댓글 수정 진입 시 해당 댓글을 리스트 상단으로 `scrollToIndex`하여 키보드가 올라와도 입력창이 가리지 않도록 수정
- 렌더되지 않은 인덱스 대비 `onScrollToIndexFailed` 폴백 추가

## 문제 상황
상세 화면의 `KeyboardAvoidingView`는 정상 적용되어 있으나 내부 컨테이너가 `FlatList`였음. `ScrollView`와 달리 `FlatList`는 포커스된 `TextInput`으로 자동 스크롤하지 않아, 리스트 하단에 위치한 댓글을 수정하면 입력창이 키보드에 가려지는 현상이 있었음.

## Test plan
- [ ] iOS에서 리스트 하단 댓글 수정 시 해당 댓글이 상단으로 스크롤되는지 확인
- [ ] Android에서 동일 시나리오 확인
- [ ] 아직 스크롤되지 않은 (뒤쪽 페이지) 댓글 수정 시 폴백 동작 확인
- [ ] 댓글 작성(create) 플로우에 회귀 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)