### PR TITLE
fix: 댓글 수정 시 keyboardDidShow 후 스크롤하도록 수정

### DIFF
--- a/src/widgets/epigram-detail-list/ui/EpigramDetailList.tsx
+++ b/src/widgets/epigram-detail-list/ui/EpigramDetailList.tsx
@@ -1,6 +1,6 @@
 import { MessageCircle } from "lucide-react-native";
-import { useCallback, useMemo, useRef, type ReactElement } from "react";
-import { ActivityIndicator, FlatList, Text, View } from "react-native";
+import { useCallback, useEffect, useMemo, useRef, type ReactElement } from "react";
+import { ActivityIndicator, FlatList, Keyboard, Text, View } from "react-native";
 
 import { useEpigramComments, type Comment } from "~/entities/comment";
 import { useMe } from "~/entities/user";
@@ -99,12 +99,24 @@ export function EpigramDetailList({
     if (hasNextPage && !isFetchingNextPage) fetchNextPage();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  const handleStartEdit = useCallback((index: number): void => {
-    listRef.current?.scrollToIndex({
-      index,
-      viewPosition: 0,
-      animated: true,
+  const pendingEditIndexRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const subscription = Keyboard.addListener("keyboardDidShow", () => {
+      const index = pendingEditIndexRef.current;
+      if (index === null) return;
+      pendingEditIndexRef.current = null;
+      listRef.current?.scrollToIndex({
+        index,
+        viewPosition: 0,
+        animated: true,
+      });
     });
+    return () => subscription.remove();
+  }, []);
+
+  const handleStartEdit = useCallback((index: number): void => {
+    pendingEditIndexRef.current = index;
   }, []);
 
   const handleScrollToIndexFailed = useCallback(
@@ -183,7 +195,6 @@ export function EpigramDetailList({
       ItemSeparatorComponent={ItemSeparator}
       ListHeaderComponentStyle={{ marginBottom: 12 }}
       keyboardShouldPersistTaps="handled"
-      automaticallyAdjustKeyboardInsets
       onScrollToIndexFailed={handleScrollToIndexFailed}
     />
   );


### PR DESCRIPTION
## Summary
- `pendingEditIndexRef`로 수정 진입 시 인덱스만 저장
- `Keyboard.addListener("keyboardDidShow")` 시점에 `scrollToIndex` 실행
- `KeyboardAvoidingView`와 중복되던 `automaticallyAdjustKeyboardInsets` 제거

## 이전 수정(#123)이 동작하지 않은 이유
`setIsEditing(true)` 직후 즉시 `scrollToIndex`를 호출했는데, **이 시점엔 키보드가 아직 올라오지 않아 FlatList 뷰포트가 그대로**임. 콘텐츠가 화면에 다 들어맞는 경우 FlatList는 스크롤할 게 없다고 판단해서 명령이 무반응으로 끝남. 그 다음 키보드가 올라오면 KeyboardAvoidingView가 FlatList를 축소시키지만 그땐 이미 스크롤 명령이 끝난 후.

이제 `keyboardDidShow` 이벤트(키보드가 완전히 올라와 FlatList 뷰포트가 축소된 직후)에 스크롤이 일어나서, 콘텐츠가 실제로 오버플로우된 상태에서 정확한 위치로 이동함.

## Test plan
- [ ] iOS에서 리스트 하단 댓글 수정 시 해당 댓글이 상단으로 스크롤되는지 확인
- [ ] iOS에서 댓글이 1~2개뿐이라 콘텐츠가 화면에 들어맞는 경우에도 정상 동작하는지 확인
- [ ] Android에서도 회귀 없는지 확인 (Keyboard 이벤트는 양 플랫폼 모두 발생)
- [ ] 수정 → 취소 → 다시 수정 시 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)