### PR TITLE
refactor: 댓글 수정 시 즉시 scrollToIndex로 변경

### DIFF
--- a/src/widgets/epigram-detail-list/ui/EpigramDetailList.tsx
+++ b/src/widgets/epigram-detail-list/ui/EpigramDetailList.tsx
@@ -1,6 +1,6 @@
 import { MessageCircle } from "lucide-react-native";
-import { useCallback, useEffect, useMemo, useRef, type ReactElement } from "react";
-import { ActivityIndicator, FlatList, Keyboard, Text, View } from "react-native";
+import { useCallback, useMemo, useRef, type ReactElement } from "react";
+import { ActivityIndicator, FlatList, Text, View } from "react-native";
 
 import { useEpigramComments, type Comment } from "~/entities/comment";
 import { useMe } from "~/entities/user";
@@ -99,24 +99,12 @@ export function EpigramDetailList({
     if (hasNextPage && !isFetchingNextPage) fetchNextPage();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  const pendingEditIndexRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    const subscription = Keyboard.addListener("keyboardDidShow", () => {
-      const index = pendingEditIndexRef.current;
-      if (index === null) return;
-      pendingEditIndexRef.current = null;
-      listRef.current?.scrollToIndex({
-        index,
-        viewPosition: 0,
-        animated: true,
-      });
-    });
-    return () => subscription.remove();
-  }, []);
-
   const handleStartEdit = useCallback((index: number): void => {
-    pendingEditIndexRef.current = index;
+    listRef.current?.scrollToIndex({
+      index,
+      viewPosition: 0,
+      animated: true,
+    });
   }, []);
 
   const handleScrollToIndexFailed = useCallback(


### PR DESCRIPTION
## Summary
- `keyboardDidShow` 이벤트 대기를 제거하고, 수정 탭 즉시 `scrollToIndex`로 해당 댓글을 상단으로 이동
- 관련 `useEffect`, `Keyboard` 리스너, `pendingEditIndexRef` 제거

## 변경 이유
이전(#124) 방식은 키보드가 완전히 올라온 후(~250ms)에 스크롤이 시작되어 반응이 둔하게 느껴졌음. 즉시 스크롤로 단순화하여 체감 속도 개선.

## Test plan
- [ ] iOS에서 댓글 수정 시 즉시 스크롤되는지 확인
- [ ] 키보드가 완전히 올라왔을 때 수정 입력창이 가려지지 않는지 확인
- [ ] 수정 → 취소 → 재수정 시 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)