### PR TITLE
fix: 댓글 수정 키보드 가림 문제 해결 (FlatList → ScrollView + map)

### DIFF
--- a/src/widgets/epigram-detail-list/ui/CommentItem.tsx
+++ b/src/widgets/epigram-detail-list/ui/CommentItem.tsx
@@ -12,16 +12,12 @@ interface CommentItemProps {
   comment: Comment;
   epigramId: number;
   currentUserId: number | undefined;
-  index: number;
-  onStartEdit: (index: number) => void;
 }
 
 function CommentItemBase({
   comment,
   epigramId,
   currentUserId,
-  index,
-  onStartEdit,
 }: CommentItemProps): ReactElement {
   const [isEditing, setIsEditing] = useState(false);
   const { deleteComment } = useCommentDelete({
@@ -32,17 +28,12 @@ function CommentItemBase({
   const isOwnComment =
     currentUserId !== undefined && comment.writer.id === currentUserId;
 
-  function handleStartEdit(): void {
-    setIsEditing(true);
-    onStartEdit(index);
-  }
-
   function handleOpenMenu(): void {
     Alert.alert(
       "댓글",
       undefined,
       [
-        { text: "수정", onPress: handleStartEdit },
+        { text: "수정", onPress: () => setIsEditing(true) },
         { text: "삭제", style: "destructive", onPress: deleteComment },
         { text: "취소", style: "cancel" },
       ],

--- a/src/widgets/epigram-detail-list/ui/EpigramDetailList.tsx
+++ b/src/widgets/epigram-detail-list/ui/EpigramDetailList.tsx
@@ -1,8 +1,8 @@
 import { MessageCircle } from "lucide-react-native";
-import { useCallback, useMemo, useRef, type ReactElement } from "react";
-import { ActivityIndicator, FlatList, Text, View } from "react-native";
+import { useCallback, useMemo, type ReactElement } from "react";
+import { ActivityIndicator, ScrollView, Text, View } from "react-native";
 
-import { useEpigramComments, type Comment } from "~/entities/comment";
+import { useEpigramComments } from "~/entities/comment";
 import { useMe } from "~/entities/user";
 import { CommentForm } from "~/features/comment-create";
 
@@ -10,7 +10,6 @@ import { CommentItem } from "./CommentItem";
 
 const COMMENTS_PAGE_SIZE = 5;
 const SKELETON_COUNT = 3;
-const END_REACHED_THRESHOLD = 0.4;
 
 interface EpigramDetailListProps {
   epigramId: number;
@@ -22,10 +21,6 @@ interface SectionHeaderProps {
   epigramId: number;
   author: { nickname: string; image: string | null } | null;
   userId: number | undefined;
-}
-
-function ItemSeparator(): ReactElement {
-  return <View className="h-3" />;
 }
 
 function CommentSkeleton(): ReactElement {
@@ -80,7 +75,6 @@ export function EpigramDetailList({
   listHeader,
 }: EpigramDetailListProps): ReactElement {
   const { user: me } = useMe();
-  const listRef = useRef<FlatList<Comment>>(null);
   const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
     useEpigramComments({ epigramId, limit: COMMENTS_PAGE_SIZE });
 
@@ -95,44 +89,34 @@ export function EpigramDetailList({
     [me],
   );
 
-  const handleEndReached = useCallback((): void => {
-    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
-
-  const handleStartEdit = useCallback((index: number): void => {
-    listRef.current?.scrollToIndex({
-      index,
-      viewPosition: 0,
-      animated: true,
-    });
-  }, []);
-
-  const handleScrollToIndexFailed = useCallback(
-    (info: { index: number; averageItemLength: number }): void => {
-      listRef.current?.scrollToOffset({
-        offset: info.averageItemLength * info.index,
-        animated: true,
-      });
+  const handleScroll = useCallback(
+    (event: {
+      nativeEvent: {
+        contentOffset: { y: number };
+        contentSize: { height: number };
+        layoutMeasurement: { height: number };
+      };
+    }): void => {
+      const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent;
+      const distanceFromBottom =
+        contentSize.height - contentOffset.y - layoutMeasurement.height;
+      if (distanceFromBottom < 200 && hasNextPage && !isFetchingNextPage) {
+        fetchNextPage();
+      }
     },
-    [],
+    [hasNextPage, isFetchingNextPage, fetchNextPage],
   );
 
-  const renderItem = useCallback(
-    ({ item, index }: { item: Comment; index: number }) => (
-      <CommentItem
-        comment={item}
-        epigramId={epigramId}
-        currentUserId={currentUserId}
-        index={index}
-        onStartEdit={handleStartEdit}
-      />
-    ),
-    [epigramId, currentUserId, handleStartEdit],
-  );
+  const hasComments = comments.length > 0;
 
-  const headerElement = useMemo(
-    () => (
-      <View className="gap-6">
+  return (
+    <ScrollView
+      contentContainerClassName="px-screen-x pb-10"
+      keyboardShouldPersistTaps="handled"
+      onScroll={handleScroll}
+      scrollEventThrottle={32}
+    >
+      <View className="gap-6" style={{ marginBottom: 12 }}>
         {listHeader}
         <SectionHeader
           totalCount={totalCount}
@@ -141,49 +125,39 @@ export function EpigramDetailList({
           userId={currentUserId}
         />
       </View>
-    ),
-    [listHeader, totalCount, epigramId, author, currentUserId],
-  );
 
-  const renderEmpty = useCallback((): ReactElement => {
-    if (isLoading) {
-      return (
+      {!hasComments && isLoading && (
         <View className="gap-3 pt-4">
           {Array.from({ length: SKELETON_COUNT }).map((_, index) => (
             <CommentSkeleton key={index} />
           ))}
         </View>
-      );
-    }
-    return (
-      <View className="pt-4">
-        <EmptyState />
-      </View>
-    );
-  }, [isLoading]);
+      )}
 
-  const footerElement = isFetchingNextPage ? (
-    <View className="py-4">
-      <ActivityIndicator color="#6a82a9" />
-    </View>
-  ) : null;
+      {!hasComments && !isLoading && (
+        <View className="pt-4">
+          <EmptyState />
+        </View>
+      )}
 
-  return (
-    <FlatList
-      ref={listRef}
-      data={comments}
-      keyExtractor={(comment) => String(comment.id)}
-      renderItem={renderItem}
-      ListHeaderComponent={headerElement}
-      ListEmptyComponent={renderEmpty}
-      ListFooterComponent={footerElement}
-      onEndReached={handleEndReached}
-      onEndReachedThreshold={END_REACHED_THRESHOLD}
-      contentContainerClassName="px-screen-x pb-10"
-      ItemSeparatorComponent={ItemSeparator}
-      ListHeaderComponentStyle={{ marginBottom: 12 }}
-      keyboardShouldPersistTaps="handled"
-      onScrollToIndexFailed={handleScrollToIndexFailed}
-    />
+      {hasComments && (
+        <View className="gap-3">
+          {comments.map((comment) => (
+            <CommentItem
+              key={comment.id}
+              comment={comment}
+              epigramId={epigramId}
+              currentUserId={currentUserId}
+            />
+          ))}
+        </View>
+      )}
+
+      {isFetchingNextPage && (
+        <View className="py-4">
+          <ActivityIndicator color="#6a82a9" />
+        </View>
+      )}
+    </ScrollView>
   );
 }


### PR DESCRIPTION
## Summary
- `EpigramDetailList`의 `FlatList` → `ScrollView + comments.map()` 으로 교체
- 무한 스크롤은 `onScroll`에서 거리 기반으로 직접 구현
- `CommentItem`에서 직전 PR들에서 추가했던 `index` / `onStartEdit` prop 제거 (스크롤 책임이 ScrollView로 이동)

## 문제와 해결 원리
`FlatList`는 포커스된 `TextInput`으로 자동 스크롤하는 기본 동작이 없어, 댓글 수정 시 입력창이 키보드에 가려졌음. `ScrollView`는 iOS에서 포커스된 입력을 자동으로 키보드 위로 스크롤해주는 기본 동작이 있어 별도 핵 없이 해결됨.

상위 `EpigramDetailScreen`의 `KeyboardAvoidingView`가 키보드 높이만큼 ScrollView를 축소시키고, ScrollView 내부 동작이 포커스된 입력을 가시 영역으로 옮긴다.

## 트레이드오프
- 가상화 손실: 모든 댓글이 한 번에 렌더됨. 댓글이 페이지당 5개씩 페이지네이션되고 상세 화면에서 수백개 이상 보이는 일이 없어 이번 사용 패턴엔 문제 없음
- Expo Go 호환성 유지 (네이티브 모듈 추가 없음 → OTA 배포 가능)

## 정리된 코드
- 직전 PR(#123, #124, #125)들에서 누적된 모든 핵 제거: `editingIndex` state, `EDITING_PADDING`, `useEffect` 키보드 처리, `pendingEditIndexRef`, `scrollToIndex`, `onScrollToIndexFailed`, `listRef`, `useState`, `useEffect`, `useRef` 임포트

## Test plan
- [ ] iOS Expo Go에서 QR 스캔 → 로그인 → 에피그램 상세 → 댓글 수정 시 입력창이 키보드 위로 자동 스크롤되는지 확인
- [ ] 댓글이 1~2개뿐인 경우에도 정상 동작 확인
- [ ] 댓글 작성(create) 정상 동작 확인
- [ ] 무한 스크롤 (5개 이상 댓글) 정상 페치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)