### PR TITLE
refactor: 댓글 편집 상태를 부모로 끌어올려 한 번에 하나만 편집

### DIFF
--- a/src/widgets/epigram-detail-list/ui/CommentItem.tsx
+++ b/src/widgets/epigram-detail-list/ui/CommentItem.tsx
@@ -1,5 +1,5 @@
 import { MoreVertical } from "lucide-react-native";
-import { memo, useState, type ReactElement } from "react";
+import { memo, type ReactElement } from "react";
 import { Alert, Pressable, Text, View } from "react-native";
 
 import { type Comment } from "~/entities/comment";
@@ -12,14 +12,19 @@ interface CommentItemProps {
   comment: Comment;
   epigramId: number;
   currentUserId: number | undefined;
+  isEditing: boolean;
+  onStartEdit: (commentId: number) => void;
+  onEndEdit: () => void;
 }
 
 function CommentItemBase({
   comment,
   epigramId,
   currentUserId,
+  isEditing,
+  onStartEdit,
+  onEndEdit,
 }: CommentItemProps): ReactElement {
-  const [isEditing, setIsEditing] = useState(false);
   const { deleteComment } = useCommentDelete({
     commentId: comment.id,
     epigramId,
@@ -33,7 +38,7 @@ function CommentItemBase({
       "댓글",
       undefined,
       [
-        { text: "수정", onPress: () => setIsEditing(true) },
+        { text: "수정", onPress: () => onStartEdit(comment.id) },
         { text: "삭제", style: "destructive", onPress: deleteComment },
         { text: "취소", style: "cancel" },
       ],
@@ -48,7 +53,7 @@ function CommentItemBase({
         epigramId={epigramId}
         initialContent={comment.content}
         initialIsPrivate={comment.isPrivate}
-        onCancel={() => setIsEditing(false)}
+        onCancel={onEndEdit}
       />
     );
   }

--- a/src/widgets/epigram-detail-list/ui/EpigramDetailList.tsx
+++ b/src/widgets/epigram-detail-list/ui/EpigramDetailList.tsx
@@ -1,5 +1,5 @@
 import { MessageCircle } from "lucide-react-native";
-import { useCallback, useMemo, useRef, type ReactElement } from "react";
+import { useCallback, useMemo, useRef, useState, type ReactElement } from "react";
 import { ActivityIndicator, FlatList, Text, View } from "react-native";
 
 import { useEpigramComments, type Comment } from "~/entities/comment";
@@ -101,6 +101,16 @@ export function EpigramDetailList({
 
   const { onScroll } = useScrollToFocusedInput(listRef, KEYBOARD_BREATHING_ROOM);
 
+  const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
+
+  const handleStartEdit = useCallback((commentId: number): void => {
+    setEditingCommentId(commentId);
+  }, []);
+
+  const handleEndEdit = useCallback((): void => {
+    setEditingCommentId(null);
+  }, []);
+
   const handleEndReached = useCallback((): void => {
     if (hasNextPage && !isFetchingNextPage) fetchNextPage();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
@@ -111,9 +121,12 @@ export function EpigramDetailList({
         comment={item}
         epigramId={epigramId}
         currentUserId={currentUserId}
+        isEditing={editingCommentId === item.id}
+        onStartEdit={handleStartEdit}
+        onEndEdit={handleEndEdit}
       />
     ),
-    [epigramId, currentUserId],
+    [epigramId, currentUserId, editingCommentId, handleStartEdit, handleEndEdit],
   );
 
   const headerElement = useMemo(


### PR DESCRIPTION
## 문제
`isEditing` 상태가 `CommentItem` 로컬 state였기 때문에 여러 댓글을 동시에 편집 상태로 열 수 있었음. 사용자가 수정 중에 다른 댓글 "수정" 탭하면 두 폼이 모두 열려 있어 혼란.

## 해결 — 편집 상태를 부모로 끌어올림
`editingCommentId: number | null` 을 `EpigramDetailList`로 lift up. 단일 진실 공급원이 되어 한 번에 하나의 폼만 열림.

- **EpigramDetailList**: `editingCommentId` state + `handleStartEdit/handleEndEdit` 핸들러 추가. `renderItem`에서 `isEditing={editingCommentId === item.id}` 계산해 전달
- **CommentItem**: 로컬 `useState` 제거. `isEditing` / `onStartEdit` / `onEndEdit` props로 수신

## 동작
편집 중 다른 댓글 수정 탭 → `editingCommentId`가 새 ID로 교체 → 이전 폼은 `isEditing=false`로 자동 닫힘 → 새 폼만 열림.

입력한 내용이 날아가는 확인 다이얼로그는 생략 — 댓글처럼 짧은 입력엔 다이얼로그가 오히려 피로함 (YouTube/Twitter/Reddit 등 표준 UX).

## Test plan
- [ ] 댓글 A 편집 시작 → 댓글 B 수정 탭 → A 폼 닫히고 B 폼만 열림
- [ ] 편집 중 취소/저장 시 정상 닫힘
- [ ] 새 댓글 작성(create) 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)