### PR TITLE
refactor: ScreenLayout 공통 컴포넌트 + useInfiniteListQuery 공통 훅 추출

### DIFF
--- a/src/entities/comment/api/useEpigramComments.ts
+++ b/src/entities/comment/api/useEpigramComments.ts
@@ -1,7 +1,7 @@
-import { useInfiniteQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
-
-import { apiClient } from "~/shared/api/client";
+import {
+  useInfiniteListQuery,
+  type UseInfiniteListQueryResult,
+} from "~/shared/api/useInfiniteListQuery";
 
 import { commentListResponseSchema, type Comment } from "../model/schema";
 import { commentKeys } from "./keys";
@@ -11,48 +11,22 @@ interface UseEpigramCommentsParams {
   limit: number;
 }
 
-interface UseEpigramCommentsResult {
+export interface UseEpigramCommentsResult
+  extends Omit<UseInfiniteListQueryResult<Comment>, "items"> {
   comments: Comment[];
-  totalCount: number | undefined;
-  isLoading: boolean;
-  isError: boolean;
-  isFetchingNextPage: boolean;
-  hasNextPage: boolean;
-  fetchNextPage: () => void;
 }
 
 export function useEpigramComments({
   epigramId,
   limit,
 }: UseEpigramCommentsParams): UseEpigramCommentsResult {
-  const query = useInfiniteQuery({
+  const { items, ...rest } = useInfiniteListQuery({
     queryKey: commentKeys.byEpigramList(epigramId, { limit }),
+    endpoint: `/epigrams/${epigramId}/comments`,
+    limit,
+    schema: commentListResponseSchema,
     enabled: epigramId > 0,
-    queryFn: async ({ pageParam }) => {
-      const params = new URLSearchParams({ limit: String(limit) });
-      if (pageParam !== undefined) params.set("cursor", String(pageParam));
-
-      const response = await apiClient.get<unknown>(
-        `/epigrams/${epigramId}/comments?${params}`,
-      );
-      return commentListResponseSchema.parse(response.data);
-    },
-    initialPageParam: undefined as number | undefined,
-    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
   });
 
-  const comments = useMemo(
-    () => query.data?.pages.flatMap((page) => page.list) ?? [],
-    [query.data?.pages],
-  );
-
-  return {
-    comments,
-    totalCount: query.data?.pages[0]?.totalCount,
-    isLoading: query.isLoading,
-    isError: query.isError,
-    isFetchingNextPage: query.isFetchingNextPage,
-    hasNextPage: query.hasNextPage,
-    fetchNextPage: query.fetchNextPage,
-  };
+  return { ...rest, comments: items };
 }

--- a/src/entities/comment/api/useMyComments.ts
+++ b/src/entities/comment/api/useMyComments.ts
@@ -1,15 +1,9 @@
 import {
-  useInfiniteQuery,
-  type InfiniteData,
-  type UseInfiniteQueryResult,
-} from "@tanstack/react-query";
+  useInfiniteListQuery,
+  type UseInfiniteListQueryResult,
+} from "~/shared/api/useInfiniteListQuery";
 
-import { apiClient } from "~/shared/api/client";
-
-import {
-  commentListResponseSchema,
-  type CommentListResponse,
-} from "../model/schema";
+import { commentListResponseSchema, type Comment } from "../model/schema";
 import { commentKeys } from "./keys";
 
 interface UseMyCommentsParams {
@@ -20,23 +14,12 @@ interface UseMyCommentsParams {
 export function useMyComments({
   userId,
   limit,
-}: UseMyCommentsParams): UseInfiniteQueryResult<
-  InfiniteData<CommentListResponse, number | undefined>,
-  Error
-> {
-  return useInfiniteQuery({
+}: UseMyCommentsParams): UseInfiniteListQueryResult<Comment> {
+  return useInfiniteListQuery({
     queryKey: commentKeys.byUserList(userId, { limit }),
+    endpoint: `/users/${userId}/comments`,
+    limit,
+    schema: commentListResponseSchema,
     enabled: userId > 0,
-    queryFn: async ({ pageParam }) => {
-      const params = new URLSearchParams({ limit: String(limit) });
-      if (pageParam !== undefined) params.set("cursor", String(pageParam));
-
-      const response = await apiClient.get<unknown>(
-        `/users/${userId}/comments?${params}`,
-      );
-      return commentListResponseSchema.parse(response.data);
-    },
-    initialPageParam: undefined as number | undefined,
-    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
   });
 }

--- a/src/entities/comment/api/useRecentComments.ts
+++ b/src/entities/comment/api/useRecentComments.ts
@@ -1,15 +1,9 @@
 import {
-  useInfiniteQuery,
-  type InfiniteData,
-  type UseInfiniteQueryResult,
-} from "@tanstack/react-query";
+  useInfiniteListQuery,
+  type UseInfiniteListQueryResult,
+} from "~/shared/api/useInfiniteListQuery";
 
-import { apiClient } from "~/shared/api/client";
-
-import {
-  commentListResponseSchema,
-  type CommentListResponse,
-} from "../model/schema";
+import { commentListResponseSchema, type Comment } from "../model/schema";
 import { commentKeys } from "./keys";
 
 interface UseRecentCommentsParams {
@@ -18,20 +12,11 @@ interface UseRecentCommentsParams {
 
 export function useRecentComments({
   limit,
-}: UseRecentCommentsParams): UseInfiniteQueryResult<
-  InfiniteData<CommentListResponse, number | undefined>,
-  Error
-> {
-  return useInfiniteQuery({
+}: UseRecentCommentsParams): UseInfiniteListQueryResult<Comment> {
+  return useInfiniteListQuery({
     queryKey: commentKeys.recent({ limit }),
-    queryFn: async ({ pageParam }) => {
-      const params = new URLSearchParams({ limit: String(limit) });
-      if (pageParam !== undefined) params.set("cursor", String(pageParam));
-
-      const response = await apiClient.get<unknown>(`/comments?${params}`);
-      return commentListResponseSchema.parse(response.data);
-    },
-    initialPageParam: undefined as number | undefined,
-    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    endpoint: "/comments",
+    limit,
+    schema: commentListResponseSchema,
   });
 }

--- a/src/entities/epigram/api/useEpigrams.ts
+++ b/src/entities/epigram/api/useEpigrams.ts
@@ -1,15 +1,9 @@
 import {
-  useInfiniteQuery,
-  type InfiniteData,
-  type UseInfiniteQueryResult,
-} from "@tanstack/react-query";
+  useInfiniteListQuery,
+  type UseInfiniteListQueryResult,
+} from "~/shared/api/useInfiniteListQuery";
 
-import { apiClient } from "~/shared/api/client";
-
-import {
-  epigramListResponseSchema,
-  type EpigramListResponse,
-} from "../model/schema";
+import { epigramListResponseSchema, type Epigram } from "../model/schema";
 import { epigramKeys } from "./keys";
 
 interface UseEpigramsParams {
@@ -22,22 +16,16 @@ export function useEpigrams({
   limit,
   keyword,
   writerId,
-}: UseEpigramsParams): UseInfiniteQueryResult<
-  InfiniteData<EpigramListResponse, number | undefined>,
-  Error
-> {
-  return useInfiniteQuery({
-    queryKey: epigramKeys.list({ limit, keyword, writerId }),
-    queryFn: async ({ pageParam }) => {
-      const params = new URLSearchParams({ limit: String(limit) });
-      if (pageParam !== undefined) params.set("cursor", String(pageParam));
-      if (keyword) params.set("keyword", keyword);
-      if (writerId !== undefined) params.set("writerId", String(writerId));
+}: UseEpigramsParams): UseInfiniteListQueryResult<Epigram> {
+  const searchParams: Record<string, string | number> = {};
+  if (keyword) searchParams.keyword = keyword;
+  if (writerId !== undefined) searchParams.writerId = writerId;
 
-      const response = await apiClient.get<unknown>(`/epigrams?${params}`);
-      return epigramListResponseSchema.parse(response.data);
-    },
-    initialPageParam: undefined as number | undefined,
-    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+  return useInfiniteListQuery({
+    queryKey: epigramKeys.list({ limit, keyword, writerId }),
+    endpoint: "/epigrams",
+    limit,
+    schema: epigramListResponseSchema,
+    searchParams,
   });
 }

--- a/src/entities/epigram/api/useSearchEpigrams.ts
+++ b/src/entities/epigram/api/useSearchEpigrams.ts
@@ -1,15 +1,9 @@
 import {
-  useInfiniteQuery,
-  type InfiniteData,
-  type UseInfiniteQueryResult,
-} from "@tanstack/react-query";
+  useInfiniteListQuery,
+  type UseInfiniteListQueryResult,
+} from "~/shared/api/useInfiniteListQuery";
 
-import { apiClient } from "~/shared/api/client";
-
-import {
-  epigramListResponseSchema,
-  type EpigramListResponse,
-} from "../model/schema";
+import { epigramListResponseSchema, type Epigram } from "../model/schema";
 import { epigramKeys } from "./keys";
 
 interface UseSearchEpigramsParams {
@@ -20,21 +14,13 @@ interface UseSearchEpigramsParams {
 export function useSearchEpigrams({
   keyword,
   limit,
-}: UseSearchEpigramsParams): UseInfiniteQueryResult<
-  InfiniteData<EpigramListResponse, number | undefined>,
-  Error
-> {
-  return useInfiniteQuery({
+}: UseSearchEpigramsParams): UseInfiniteListQueryResult<Epigram> {
+  return useInfiniteListQuery({
     queryKey: epigramKeys.search(keyword),
-    queryFn: async ({ pageParam }) => {
-      const params = new URLSearchParams({ limit: String(limit), keyword });
-      if (pageParam !== undefined) params.set("cursor", String(pageParam));
-
-      const response = await apiClient.get<unknown>(`/epigrams?${params}`);
-      return epigramListResponseSchema.parse(response.data);
-    },
-    initialPageParam: undefined as number | undefined,
-    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    endpoint: "/epigrams",
+    limit,
+    schema: epigramListResponseSchema,
+    searchParams: { keyword },
     enabled: keyword.trim().length > 0,
   });
 }

--- a/src/features/epigram-edit/model/useEpigramEdit.ts
+++ b/src/features/epigram-edit/model/useEpigramEdit.ts
@@ -54,9 +54,6 @@ export function useEpigramEdit(epigramId: number): UseEpigramEditReturn {
       }),
     onSuccess: (epigram) => {
       queryClient.invalidateQueries({ queryKey: epigramKeys.all });
-      queryClient.invalidateQueries({
-        queryKey: epigramKeys.detail(epigramId),
-      });
       if (router.canGoBack()) {
         router.back();
         return;

--- a/src/features/epigram-search/ui/SearchResults.tsx
+++ b/src/features/epigram-search/ui/SearchResults.tsx
@@ -71,13 +71,13 @@ function SearchNoResults({ keyword }: SearchNoResultsProps): ReactElement {
 }
 
 export function SearchResults({ keyword }: SearchResultsProps): ReactElement {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
-    useSearchEpigrams({ keyword, limit: SEARCH_LIMIT });
-
-  const epigrams = useMemo(
-    () => data?.pages.flatMap((page) => page.list) ?? [],
-    [data?.pages],
-  );
+  const {
+    items: epigrams,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+  } = useSearchEpigrams({ keyword, limit: SEARCH_LIMIT });
 
   const highlightRegex = useMemo(() => buildHighlightRegex(keyword), [keyword]);
 

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -8,3 +8,5 @@ export {
 } from "./tokenStorage";
 export { uploadImage, toUploadImageFile } from "./uploadImage";
 export type { UploadImageFile } from "./uploadImage";
+export { useInfiniteListQuery } from "./useInfiniteListQuery";
+export type { UseInfiniteListQueryResult } from "./useInfiniteListQuery";

--- a/src/shared/api/useInfiniteListQuery.ts
+++ b/src/shared/api/useInfiniteListQuery.ts
@@ -1,0 +1,70 @@
+import { useInfiniteQuery, type QueryKey } from "@tanstack/react-query";
+import { useMemo } from "react";
+import type { z, ZodTypeAny } from "zod";
+
+import type { PaginatedSchemaOf } from "~/shared/types/pagination";
+
+import { apiClient } from "./client";
+
+interface UseInfiniteListQueryParams<TItem extends ZodTypeAny> {
+  queryKey: QueryKey;
+  endpoint: string;
+  limit: number;
+  schema: PaginatedSchemaOf<TItem>;
+  searchParams?: Record<string, string | number>;
+  enabled?: boolean;
+}
+
+export interface UseInfiniteListQueryResult<TItem> {
+  items: TItem[];
+  totalCount: number | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  isFetchingNextPage: boolean;
+  hasNextPage: boolean;
+  fetchNextPage: () => void;
+}
+
+export function useInfiniteListQuery<TItem extends ZodTypeAny>({
+  queryKey,
+  endpoint,
+  limit,
+  schema,
+  searchParams,
+  enabled = true,
+}: UseInfiniteListQueryParams<TItem>): UseInfiniteListQueryResult<
+  z.infer<TItem>
+> {
+  const query = useInfiniteQuery({
+    queryKey,
+    enabled,
+    queryFn: async ({ pageParam }) => {
+      const sp = new URLSearchParams({ limit: String(limit) });
+      if (pageParam !== undefined) sp.set("cursor", String(pageParam));
+      if (searchParams) {
+        for (const [key, value] of Object.entries(searchParams)) {
+          sp.set(key, String(value));
+        }
+      }
+      const response = await apiClient.get<unknown>(`${endpoint}?${sp}`);
+      return schema.parse(response.data);
+    },
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+  });
+
+  const items = useMemo(
+    () => query.data?.pages.flatMap((page) => page.list) ?? [],
+    [query.data?.pages],
+  );
+
+  return {
+    items,
+    totalCount: query.data?.pages[0]?.totalCount,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    isFetchingNextPage: query.isFetchingNextPage,
+    hasNextPage: query.hasNextPage,
+    fetchNextPage: query.fetchNextPage,
+  };
+}

--- a/src/shared/ui/ScreenLayout.tsx
+++ b/src/shared/ui/ScreenLayout.tsx
@@ -1,0 +1,38 @@
+import type { ReactElement, ReactNode } from "react";
+import { KeyboardAvoidingView, Platform, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { HeaderBackButton } from "~/widgets/header";
+
+interface ScreenLayoutProps {
+  children: ReactNode;
+  headerRight?: ReactElement;
+  withKeyboardAvoiding?: boolean;
+}
+
+export function ScreenLayout({
+  children,
+  headerRight,
+  withKeyboardAvoiding = true,
+}: ScreenLayoutProps): ReactElement {
+  const body = withKeyboardAvoiding ? (
+    <KeyboardAvoidingView
+      className="flex-1"
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+    >
+      {children}
+    </KeyboardAvoidingView>
+  ) : (
+    <View className="flex-1">{children}</View>
+  );
+
+  return (
+    <SafeAreaView className="flex-1 bg-background" edges={["top"]}>
+      <View className="flex-row items-center justify-between px-screen-x py-2">
+        <HeaderBackButton />
+        {headerRight}
+      </View>
+      {body}
+    </SafeAreaView>
+  );
+}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -6,5 +6,6 @@ export { Input } from "./Input";
 export type { InputProps } from "./Input";
 export { LoadingState } from "./LoadingState";
 export { PrivacyToggle } from "./PrivacyToggle";
+export { ScreenLayout } from "./ScreenLayout";
 export { SectionErrorFallback } from "./SectionErrorFallback";
 export { UserAvatar } from "./UserAvatar";

--- a/src/views/add-epigram/ui/AddEpigramScreen.tsx
+++ b/src/views/add-epigram/ui/AddEpigramScreen.tsx
@@ -1,12 +1,5 @@
 import { type ReactElement } from "react";
-import {
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
-  Text,
-  View,
-} from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { ScrollView, Text, View } from "react-native";
 
 import { useMe } from "~/entities/user";
 import {
@@ -14,9 +7,8 @@ import {
   useEpigramCreate,
   type EpigramCreateFormValues,
 } from "~/features/epigram-create";
-import { LoadingState } from "~/shared/ui";
+import { LoadingState, ScreenLayout } from "~/shared/ui";
 import { EpigramForm } from "~/widgets/epigram-form";
-import { HeaderBackButton } from "~/widgets/header";
 
 const WRITING_TIPS = [
   "500자 이내의 짧고 인상적인 문장을 담아보세요.",
@@ -63,37 +55,29 @@ export function AddEpigramScreen(): ReactElement | null {
   if (isMeLoading || !user) return <LoadingState />;
 
   return (
-    <SafeAreaView className="flex-1 bg-background" edges={["top"]}>
-      <View className="flex-row items-center px-screen-x py-2">
-        <HeaderBackButton />
-      </View>
-      <KeyboardAvoidingView
+    <ScreenLayout>
+      <ScrollView
         className="flex-1"
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        contentContainerClassName="px-screen-x pb-12 pt-2 gap-6"
+        keyboardShouldPersistTaps="handled"
       >
-        <ScrollView
-          className="flex-1"
-          contentContainerClassName="px-screen-x pb-12 pt-2 gap-6"
-          keyboardShouldPersistTaps="handled"
-        >
-          <Text className="font-serif-bold text-2xl text-black-900">
-            에피그램 작성
-          </Text>
-          <WritingTips />
-          <EpigramForm
-            defaultValues={DEFAULT_VALUES}
-            onSubmit={submit}
-            isSubmitting={isSubmitting}
-            hasError={hasError}
-            errorMessage="에피그램을 등록하지 못했습니다. 잠시 후 다시 시도해주세요."
-            submitLabel="등록"
-            tagInput={tagInput}
-            onTagInputChange={handleTagInputChange}
-            onAddTag={handleAddTag}
-            onRemoveTag={handleRemoveTag}
-          />
-        </ScrollView>
-      </KeyboardAvoidingView>
-    </SafeAreaView>
+        <Text className="font-serif-bold text-2xl text-black-900">
+          에피그램 작성
+        </Text>
+        <WritingTips />
+        <EpigramForm
+          defaultValues={DEFAULT_VALUES}
+          onSubmit={submit}
+          isSubmitting={isSubmitting}
+          hasError={hasError}
+          errorMessage="에피그램을 등록하지 못했습니다. 잠시 후 다시 시도해주세요."
+          submitLabel="등록"
+          tagInput={tagInput}
+          onTagInputChange={handleTagInputChange}
+          onAddTag={handleAddTag}
+          onRemoveTag={handleRemoveTag}
+        />
+      </ScrollView>
+    </ScreenLayout>
   );
 }

--- a/src/views/epigram-detail/ui/EpigramDetailScreen.tsx
+++ b/src/views/epigram-detail/ui/EpigramDetailScreen.tsx
@@ -1,22 +1,14 @@
 import { router } from "expo-router";
 import { MoreVertical } from "lucide-react-native";
 import { type ReactElement } from "react";
-import {
-  Alert,
-  KeyboardAvoidingView,
-  Platform,
-  Pressable,
-  View,
-} from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { Alert, Pressable } from "react-native";
 
 import { useEpigramDetail } from "~/entities/epigram";
 import { useMe } from "~/entities/user";
 import { useEpigramDelete } from "~/features/epigram-delete";
-import { ErrorState, LoadingState } from "~/shared/ui";
+import { ErrorState, LoadingState, ScreenLayout } from "~/shared/ui";
 import { EpigramDetailCard } from "~/widgets/epigram-detail-card";
 import { EpigramDetailList } from "~/widgets/epigram-detail-list";
-import { HeaderBackButton } from "~/widgets/header";
 
 interface EpigramDetailScreenProps {
   epigramId: number;
@@ -86,17 +78,10 @@ export function EpigramDetailScreen({
   }
 
   return (
-    <SafeAreaView className="flex-1 bg-background" edges={["top"]}>
-      <View className="flex-row items-center justify-between px-screen-x py-2">
-        <HeaderBackButton />
-        {isOwner && <ActionMenu epigramId={epigramId} />}
-      </View>
-      <KeyboardAvoidingView
-        className="flex-1"
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
-      >
-        {renderBody()}
-      </KeyboardAvoidingView>
-    </SafeAreaView>
+    <ScreenLayout
+      headerRight={isOwner ? <ActionMenu epigramId={epigramId} /> : undefined}
+    >
+      {renderBody()}
+    </ScreenLayout>
   );
 }

--- a/src/views/epigram-edit/ui/EpigramEditScreen.tsx
+++ b/src/views/epigram-edit/ui/EpigramEditScreen.tsx
@@ -1,20 +1,12 @@
 import { Redirect } from "expo-router";
 import { type ReactElement } from "react";
-import {
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
-  Text,
-  View,
-} from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { ScrollView, Text } from "react-native";
 
 import { useEpigramDetail } from "~/entities/epigram";
 import { useMe } from "~/entities/user";
 import { resolveDefaultValues, useEpigramEdit } from "~/features/epigram-edit";
-import { ErrorState, LoadingState } from "~/shared/ui";
+import { ErrorState, LoadingState, ScreenLayout } from "~/shared/ui";
 import { EpigramForm } from "~/widgets/epigram-form";
-import { HeaderBackButton } from "~/widgets/header";
 
 interface EpigramEditScreenProps {
   epigramId: number;
@@ -76,17 +68,5 @@ export function EpigramEditScreen({
     );
   }
 
-  return (
-    <SafeAreaView className="flex-1 bg-background" edges={["top"]}>
-      <View className="flex-row items-center px-screen-x py-2">
-        <HeaderBackButton />
-      </View>
-      <KeyboardAvoidingView
-        className="flex-1"
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
-      >
-        {renderBody()}
-      </KeyboardAvoidingView>
-    </SafeAreaView>
-  );
+  return <ScreenLayout>{renderBody()}</ScreenLayout>;
 }

--- a/src/views/login/ui/LoginScreen.tsx
+++ b/src/views/login/ui/LoginScreen.tsx
@@ -1,17 +1,9 @@
 import { router } from "expo-router";
 import type { ReactElement } from "react";
-import {
-  KeyboardAvoidingView,
-  Platform,
-  Pressable,
-  ScrollView,
-  Text,
-  View,
-} from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { Pressable, ScrollView, Text, View } from "react-native";
 
 import { GuestLoginButton, LoginForm } from "~/features/auth";
-import { HeaderBackButton } from "~/widgets/header";
+import { ScreenLayout } from "~/shared/ui";
 
 export function LoginScreen(): ReactElement {
   function handleGoToSignUp(): void {
@@ -19,43 +11,35 @@ export function LoginScreen(): ReactElement {
   }
 
   return (
-    <SafeAreaView className="flex-1 bg-background" edges={["top"]}>
-      <View className="flex-row items-center px-screen-x py-2">
-        <HeaderBackButton />
-      </View>
-      <KeyboardAvoidingView
+    <ScreenLayout>
+      <ScrollView
         className="flex-1"
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        contentContainerClassName="flex-grow justify-center px-screen-x py-10"
+        keyboardShouldPersistTaps="handled"
       >
-        <ScrollView
-          className="flex-1"
-          contentContainerClassName="flex-grow justify-center px-screen-x py-10"
-          keyboardShouldPersistTaps="handled"
-        >
-          <View className="mb-10 items-center gap-2">
-            <Text className="font-serif-bold text-4xl text-blue-800">
-              epigram
+        <View className="mb-10 items-center gap-2">
+          <Text className="font-serif-bold text-4xl text-blue-800">
+            epigram
+          </Text>
+          <Text className="font-sans text-sm text-black-300">
+            인생 명언을 모아보세요
+          </Text>
+        </View>
+        <LoginForm />
+        <View className="mt-3">
+          <GuestLoginButton />
+        </View>
+        <View className="mt-6 flex-row justify-center gap-1">
+          <Text className="font-sans text-sm text-black-300">
+            아직 회원이 아니신가요?
+          </Text>
+          <Pressable onPress={handleGoToSignUp} accessibilityRole="link">
+            <Text className="font-sans text-sm font-semibold text-blue-600">
+              회원가입
             </Text>
-            <Text className="font-sans text-sm text-black-300">
-              인생 명언을 모아보세요
-            </Text>
-          </View>
-          <LoginForm />
-          <View className="mt-3">
-            <GuestLoginButton />
-          </View>
-          <View className="mt-6 flex-row justify-center gap-1">
-            <Text className="font-sans text-sm text-black-300">
-              아직 회원이 아니신가요?
-            </Text>
-            <Pressable onPress={handleGoToSignUp} accessibilityRole="link">
-              <Text className="font-sans text-sm font-semibold text-blue-600">
-                회원가입
-              </Text>
-            </Pressable>
-          </View>
-        </ScrollView>
-      </KeyboardAvoidingView>
-    </SafeAreaView>
+          </Pressable>
+        </View>
+      </ScrollView>
+    </ScreenLayout>
   );
 }

--- a/src/views/signup/ui/SignUpScreen.tsx
+++ b/src/views/signup/ui/SignUpScreen.tsx
@@ -1,17 +1,9 @@
 import { router } from "expo-router";
 import type { ReactElement } from "react";
-import {
-  KeyboardAvoidingView,
-  Platform,
-  Pressable,
-  ScrollView,
-  Text,
-  View,
-} from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { Pressable, ScrollView, Text, View } from "react-native";
 
 import { SignUpForm } from "~/features/auth";
-import { HeaderBackButton } from "~/widgets/header";
+import { ScreenLayout } from "~/shared/ui";
 
 export function SignUpScreen(): ReactElement {
   function handleGoToLogin(): void {
@@ -19,38 +11,30 @@ export function SignUpScreen(): ReactElement {
   }
 
   return (
-    <SafeAreaView className="flex-1 bg-background" edges={["top"]}>
-      <View className="flex-row items-center px-screen-x py-2">
-        <HeaderBackButton />
-      </View>
-      <KeyboardAvoidingView
+    <ScreenLayout>
+      <ScrollView
         className="flex-1"
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        contentContainerClassName="flex-grow justify-center px-screen-x py-10"
+        keyboardShouldPersistTaps="handled"
       >
-        <ScrollView
-          className="flex-1"
-          contentContainerClassName="flex-grow justify-center px-screen-x py-10"
-          keyboardShouldPersistTaps="handled"
-        >
-          <View className="mb-10 items-center gap-2">
-            <Text className="font-serif-bold text-4xl text-blue-800">
-              epigram
+        <View className="mb-10 items-center gap-2">
+          <Text className="font-serif-bold text-4xl text-blue-800">
+            epigram
+          </Text>
+          <Text className="font-sans text-sm text-black-300">회원가입</Text>
+        </View>
+        <SignUpForm />
+        <View className="mt-6 flex-row justify-center gap-1">
+          <Text className="font-sans text-sm text-black-300">
+            이미 회원이신가요?
+          </Text>
+          <Pressable onPress={handleGoToLogin} accessibilityRole="link">
+            <Text className="font-sans text-sm font-semibold text-blue-600">
+              로그인
             </Text>
-            <Text className="font-sans text-sm text-black-300">회원가입</Text>
-          </View>
-          <SignUpForm />
-          <View className="mt-6 flex-row justify-center gap-1">
-            <Text className="font-sans text-sm text-black-300">
-              이미 회원이신가요?
-            </Text>
-            <Pressable onPress={handleGoToLogin} accessibilityRole="link">
-              <Text className="font-sans text-sm font-semibold text-blue-600">
-                로그인
-              </Text>
-            </Pressable>
-          </View>
-        </ScrollView>
-      </KeyboardAvoidingView>
-    </SafeAreaView>
+          </Pressable>
+        </View>
+      </ScrollView>
+    </ScreenLayout>
   );
 }

--- a/src/widgets/epigram-feed/ui/EpigramFeed.tsx
+++ b/src/widgets/epigram-feed/ui/EpigramFeed.tsx
@@ -136,7 +136,7 @@ function EpigramFeedInner(): ReactElement {
   const { user } = useMe();
   const isAuthenticated = !!user;
   const {
-    data,
+    items: epigrams,
     isLoading,
     isError,
     isFetchingNextPage,
@@ -145,8 +145,6 @@ function EpigramFeedInner(): ReactElement {
   } = useEpigrams({
     limit: FEED_PAGE_SIZE,
   });
-
-  const epigrams = data?.pages.flatMap((page) => page.list) ?? [];
 
   const renderItem = useCallback<ListRenderItem<Epigram>>(
     ({ item }) => <EpigramCard epigram={item} onPress={navigateToEpigram} />,

--- a/src/widgets/mypage-activity/ui/MyCommentList.tsx
+++ b/src/widgets/mypage-activity/ui/MyCommentList.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactElement } from "react";
+import { type ReactElement } from "react";
 import { Text, View } from "react-native";
 
 import { useMyComments } from "~/entities/comment";
@@ -12,16 +12,15 @@ interface MyCommentListProps {
 }
 
 export function MyCommentList({ userId }: MyCommentListProps): ReactElement {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useMyComments({
-      userId,
-      limit: MYPAGE_LIST_PAGE_SIZE,
-    });
-
-  const comments = useMemo(
-    () => data?.pages.flatMap((page) => page.list) ?? [],
-    [data],
-  );
+  const {
+    items: comments,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useMyComments({
+    userId,
+    limit: MYPAGE_LIST_PAGE_SIZE,
+  });
 
   if (comments.length === 0) {
     return (

--- a/src/widgets/mypage-activity/ui/MyEpigramList.tsx
+++ b/src/widgets/mypage-activity/ui/MyEpigramList.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactElement } from "react";
+import { type ReactElement } from "react";
 import { Text, View } from "react-native";
 
 import {
@@ -15,15 +15,15 @@ interface MyEpigramListProps {
 }
 
 export function MyEpigramList({ userId }: MyEpigramListProps): ReactElement {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useEpigrams({
+  const {
+    items: epigrams,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useEpigrams({
     limit: MYPAGE_LIST_PAGE_SIZE,
     writerId: userId,
   });
-
-  const epigrams = useMemo(
-    () => data?.pages.flatMap((page) => page.list) ?? [],
-    [data],
-  );
 
   if (epigrams.length === 0) {
     return (

--- a/src/widgets/mypage-activity/ui/TabbedSection.tsx
+++ b/src/widgets/mypage-activity/ui/TabbedSection.tsx
@@ -42,16 +42,14 @@ export function TabbedSection({ userId }: TabbedSectionProps): ReactElement {
     () => new Set(["epigrams"]),
   );
 
-  const { data: epigramsData } = useEpigrams({
+  const { totalCount: epigramCount = 0 } = useEpigrams({
     limit: MYPAGE_LIST_PAGE_SIZE,
     writerId: userId,
   });
-  const { data: commentsData } = useMyComments({
+  const { totalCount: commentCount = 0 } = useMyComments({
     userId,
     limit: MYPAGE_LIST_PAGE_SIZE,
   });
-  const epigramCount = epigramsData?.pages[0]?.totalCount ?? 0;
-  const commentCount = commentsData?.pages[0]?.totalCount ?? 0;
 
   function handleSelectTab(tab: ActiveTab): void {
     setActiveTab(tab);


### PR DESCRIPTION
## Summary
반복되던 두 가지 패턴을 shared 레이어로 끌어올려 각 화면/훅이 자기 책임에만 집중하도록 정리. 순 **170 LOC 감소** (172 추가 / 342 삭제).

## 1. `ScreenLayout` 공통 컴포넌트
[src/shared/ui/ScreenLayout.tsx](src/shared/ui/ScreenLayout.tsx)

5개 화면(Add/Edit/Detail/Login/SignUp)이 거의 동일하게 반복하던 레이아웃 구조:
```
SafeAreaView (edges=top)
  └─ View (header row: HeaderBackButton + optional headerRight)
  └─ KeyboardAvoidingView (behavior: iOS=padding, Android=undefined)
      └─ children
```

을 한 컴포넌트로 캡슐화. `headerRight` prop으로 우측 액션 주입 (EpigramDetailScreen의 `ActionMenu`만 사용).

## 2. `useInfiniteListQuery` 공통 훅
[src/shared/api/useInfiniteListQuery.ts](src/shared/api/useInfiniteListQuery.ts)

5개 entity 훅이 반복하던 `useInfiniteQuery + URLSearchParams + cursor 세팅 + schema.parse + flatMap(pages)` 로직을 제네릭 훅으로. 호출자는 정리된 인터페이스(`items` / `totalCount` / 로딩·페치 플래그)만 받음 → **react-query `InfiniteData` 내부 구조에 대한 의존 제거**.

**적용 훅**:
- `useEpigramComments`, `useMyComments`, `useRecentComments`
- `useEpigrams`, `useSearchEpigrams`

**소비자 업데이트 (leaky `data.pages.flatMap(...)` 제거)**:
- `EpigramFeed`, `MyEpigramList`, `MyCommentList`, `TabbedSection`, `SearchResults`

## 3. 중복 invalidation 제거
[src/features/epigram-edit/model/useEpigramEdit.ts](src/features/epigram-edit/model/useEpigramEdit.ts)
`epigramKeys.all` 이 이미 `detail` 을 포함하므로 뒤따르던 중복 detail invalidation 제거.

## 다음 단계
이번 PR은 **DRY/재사용성** 위주 리팩토링. 다음 PR들에서 각 영역 SRP/책임 분리 작업 예정:
- views 내부 (`renderBody` 함수 추출, 인라인 컴포넌트 분리 등)
- features (mutation 패턴 공통화, auth 플로우 정리)
- widgets (EpigramForm 460줄 분리, TabbedSection display:none 해크 제거)

## Test plan
- [ ] tsc / expo lint 통과 (로컬 확인 완료, CI 재확인)
- [ ] Expo Go: 로그인/회원가입/에피그램 작성/수정/상세 화면 정상 렌더
- [ ] 피드 무한 스크롤 / 검색 결과 / 마이페이지 탭별 리스트 정상 페이지네이션

🤖 Generated with [Claude Code](https://claude.com/claude-code)