### PR TITLE
refactor: features 레이어 SRP 정리 — mutation 중복 제거 + race 수정 + 에러 로깅

### DIFF
--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -2,6 +2,7 @@ export { loginSchema } from "./model/loginSchema";
 export type { LoginFormValues } from "./model/loginSchema";
 export { signUpSchema } from "./model/signUpSchema";
 export type { SignUpFormValues } from "./model/signUpSchema";
+export { useAuthMutation } from "./model/useAuthMutation";
 export { useLogout } from "./model/useLogout";
 export { useSessionExpiryRedirect } from "./model/useSessionExpiryRedirect";
 

--- a/src/features/auth/model/useAuthMutation.ts
+++ b/src/features/auth/model/useAuthMutation.ts
@@ -1,0 +1,29 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { router, type Href } from "expo-router";
+import { useCallback } from "react";
+
+import { userKeys, type User } from "~/entities/user";
+
+interface AuthResult {
+  user: User;
+}
+
+interface UseAuthMutationResult {
+  handleAuthSuccess: (result: AuthResult, redirectTo?: Href) => void;
+}
+
+const DEFAULT_REDIRECT: Href = "/feeds";
+
+export function useAuthMutation(): UseAuthMutationResult {
+  const queryClient = useQueryClient();
+
+  const handleAuthSuccess = useCallback(
+    ({ user }: AuthResult, redirectTo?: Href): void => {
+      queryClient.setQueryData(userKeys.me(), user);
+      router.replace(redirectTo ?? DEFAULT_REDIRECT);
+    },
+    [queryClient],
+  );
+
+  return { handleAuthSuccess };
+}

--- a/src/features/auth/model/useLogout.ts
+++ b/src/features/auth/model/useLogout.ts
@@ -12,9 +12,9 @@ export function useLogout(): UseLogoutReturn {
   const queryClient = useQueryClient();
 
   async function performLogout(): Promise<void> {
-    router.replace("/feeds");
     await clearTokens();
     queryClient.clear();
+    router.replace("/feeds");
   }
 
   function handleLogout(): void {

--- a/src/features/auth/ui/GuestLoginButton.tsx
+++ b/src/features/auth/ui/GuestLoginButton.tsx
@@ -1,10 +1,10 @@
-import { useQueryClient } from "@tanstack/react-query";
-import { router } from "expo-router";
 import { useState, type ReactElement } from "react";
 import { ActivityIndicator, Pressable, Text, View } from "react-native";
 
-import { signIn, userKeys } from "~/entities/user";
+import { signIn } from "~/entities/user";
 import { cn } from "~/shared/lib/cn";
+
+import { useAuthMutation } from "../model/useAuthMutation";
 
 const GUEST_CREDENTIALS = {
   email: "guest13325@naver.com",
@@ -12,7 +12,7 @@ const GUEST_CREDENTIALS = {
 } as const;
 
 export function GuestLoginButton(): ReactElement {
-  const queryClient = useQueryClient();
+  const { handleAuthSuccess } = useAuthMutation();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -20,9 +20,8 @@ export function GuestLoginButton(): ReactElement {
     setIsLoading(true);
     setError(null);
     try {
-      const { user } = await signIn(GUEST_CREDENTIALS);
-      queryClient.setQueryData(userKeys.me(), user);
-      router.replace("/feeds");
+      const result = await signIn(GUEST_CREDENTIALS);
+      handleAuthSuccess(result);
     } catch {
       setError("게스트 로그인에 실패했습니다. 잠시 후 다시 시도해주세요.");
     } finally {

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -1,13 +1,13 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useQueryClient } from "@tanstack/react-query";
-import { router, useLocalSearchParams, type Href } from "expo-router";
+import { useLocalSearchParams, type Href } from "expo-router";
 import type { ReactElement } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { View } from "react-native";
 
-import { signIn, userKeys } from "~/entities/user";
+import { signIn } from "~/entities/user";
 import { Button, Input } from "~/shared/ui";
 
+import { useAuthMutation } from "../model/useAuthMutation";
 import { loginSchema, type LoginFormValues } from "../model/loginSchema";
 
 const DEFAULT_VALUES: LoginFormValues = { email: "", password: "" };
@@ -25,7 +25,7 @@ function resolveRedirectTarget(redirect: string | undefined): Href {
 }
 
 export function LoginForm(): ReactElement {
-  const queryClient = useQueryClient();
+  const { handleAuthSuccess } = useAuthMutation();
   const { redirect } = useLocalSearchParams<{ redirect?: string }>();
   const {
     control,
@@ -40,9 +40,8 @@ export function LoginForm(): ReactElement {
 
   async function onSubmit(data: LoginFormValues): Promise<void> {
     try {
-      const { user } = await signIn(data);
-      queryClient.setQueryData(userKeys.me(), user);
-      router.replace(resolveRedirectTarget(redirect));
+      const result = await signIn(data);
+      handleAuthSuccess(result, resolveRedirectTarget(redirect));
     } catch {
       const message = "이메일 혹은 비밀번호를 확인해주세요.";
       setError("email", { message });

--- a/src/features/auth/ui/SignUpForm.tsx
+++ b/src/features/auth/ui/SignUpForm.tsx
@@ -1,14 +1,13 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useQueryClient } from "@tanstack/react-query";
 import { isAxiosError } from "axios";
-import { router } from "expo-router";
 import type { ReactElement } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { View } from "react-native";
 
-import { signUp, userKeys } from "~/entities/user";
+import { signUp } from "~/entities/user";
 import { Button, Input } from "~/shared/ui";
 
+import { useAuthMutation } from "../model/useAuthMutation";
 import { signUpSchema, type SignUpFormValues } from "../model/signUpSchema";
 
 const DEFAULT_VALUES: SignUpFormValues = {
@@ -19,7 +18,7 @@ const DEFAULT_VALUES: SignUpFormValues = {
 };
 
 export function SignUpForm(): ReactElement {
-  const queryClient = useQueryClient();
+  const { handleAuthSuccess } = useAuthMutation();
   const {
     control,
     handleSubmit,
@@ -33,9 +32,8 @@ export function SignUpForm(): ReactElement {
 
   async function onSubmit(data: SignUpFormValues): Promise<void> {
     try {
-      const { user } = await signUp(data);
-      queryClient.setQueryData(userKeys.me(), user);
-      router.replace("/feeds");
+      const result = await signUp(data);
+      handleAuthSuccess(result);
     } catch (error) {
       if (isAxiosError(error) && error.response?.status === 500) {
         setError("nickname", { message: "이미 사용 중인 닉네임입니다." });

--- a/src/features/epigram-create/index.ts
+++ b/src/features/epigram-create/index.ts
@@ -1,4 +1,5 @@
 export { EPIGRAM_CREATE_DEFAULT_VALUES } from "./model/defaultValues";
+export { resolveAuthor } from "./model/resolveAuthor";
 export {
   AUTHOR_TYPE,
   epigramCreateFormSchema,

--- a/src/features/epigram-create/model/resolveAuthor.ts
+++ b/src/features/epigram-create/model/resolveAuthor.ts
@@ -1,0 +1,18 @@
+import {
+  AUTHOR_TYPE,
+  UNKNOWN_AUTHOR,
+  type EpigramCreateFormValues,
+} from "./schema";
+
+const SELF_FALLBACK = "본인";
+
+export function resolveAuthor(
+  values: EpigramCreateFormValues,
+  userNickname?: string,
+): string {
+  if (values.authorType === AUTHOR_TYPE.UNKNOWN) return UNKNOWN_AUTHOR;
+  if (values.authorType === AUTHOR_TYPE.SELF) {
+    return userNickname ?? values.authorName ?? SELF_FALLBACK;
+  }
+  return values.authorName ?? "";
+}

--- a/src/features/epigram-create/model/useEpigramCreate.ts
+++ b/src/features/epigram-create/model/useEpigramCreate.ts
@@ -4,11 +4,8 @@ import { router } from "expo-router";
 import { createEpigram, epigramKeys } from "~/entities/epigram";
 import { useTagInput } from "~/shared/hooks/useTagInput";
 
-import {
-  AUTHOR_TYPE,
-  UNKNOWN_AUTHOR,
-  type EpigramCreateFormValues,
-} from "./schema";
+import { resolveAuthor } from "./resolveAuthor";
+import { type EpigramCreateFormValues } from "./schema";
 
 interface UseEpigramCreateReturn {
   tagInput: string;
@@ -25,15 +22,6 @@ interface UseEpigramCreateReturn {
     onChange: (tags: string[]) => void,
   ) => void;
   submit: (values: EpigramCreateFormValues) => void;
-}
-
-function resolveAuthor(
-  values: EpigramCreateFormValues,
-  userNickname: string | undefined,
-): string {
-  if (values.authorType === AUTHOR_TYPE.UNKNOWN) return UNKNOWN_AUTHOR;
-  if (values.authorType === AUTHOR_TYPE.SELF) return userNickname ?? "본인";
-  return values.authorName ?? "";
 }
 
 export function useEpigramCreate(

--- a/src/features/epigram-delete/model/useEpigramDelete.ts
+++ b/src/features/epigram-delete/model/useEpigramDelete.ts
@@ -1,22 +1,28 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { router } from "expo-router";
 import { Alert } from "react-native";
 
 import { deleteEpigram, epigramKeys } from "~/entities/epigram";
+
+interface UseEpigramDeleteOptions {
+  onSuccess?: () => void;
+}
 
 interface UseEpigramDeleteReturn {
   handleDelete: () => void;
   isDeleting: boolean;
 }
 
-export function useEpigramDelete(epigramId: number): UseEpigramDeleteReturn {
+export function useEpigramDelete(
+  epigramId: number,
+  { onSuccess }: UseEpigramDeleteOptions = {},
+): UseEpigramDeleteReturn {
   const queryClient = useQueryClient();
 
   const { mutate, isPending: isDeleting } = useMutation({
     mutationFn: () => deleteEpigram(epigramId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: epigramKeys.all });
-      router.replace("/feeds");
+      onSuccess?.();
     },
     onError: () => {
       Alert.alert(

--- a/src/features/epigram-edit/model/useEpigramEdit.ts
+++ b/src/features/epigram-edit/model/useEpigramEdit.ts
@@ -3,8 +3,7 @@ import { router } from "expo-router";
 
 import { epigramKeys, updateEpigram } from "~/entities/epigram";
 import {
-  AUTHOR_TYPE,
-  UNKNOWN_AUTHOR,
+  resolveAuthor,
   type EpigramCreateFormValues,
 } from "~/features/epigram-create";
 import { useTagInput } from "~/shared/hooks/useTagInput";
@@ -25,13 +24,6 @@ interface UseEpigramEditReturn {
   ) => void;
   handleCancel: () => void;
   submit: (values: EpigramCreateFormValues) => void;
-}
-
-function resolveAuthor(values: EpigramCreateFormValues): string {
-  if (values.authorType === AUTHOR_TYPE.UNKNOWN) return UNKNOWN_AUTHOR;
-  if (values.authorType === AUTHOR_TYPE.SELF)
-    return values.authorName ?? "본인";
-  return values.authorName ?? "";
 }
 
 export function useEpigramEdit(epigramId: number): UseEpigramEditReturn {

--- a/src/features/epigram-search/model/useRecentSearches.ts
+++ b/src/features/epigram-search/model/useRecentSearches.ts
@@ -33,14 +33,20 @@ export function useRecentSearches(): UseRecentSearchesResult {
         const parsed = parseStored(raw);
         if (parsed) setRecentSearches(parsed);
       })
-      .catch(() => {});
+      .catch((error: unknown) => {
+        console.warn("[recent-searches] load failed", error);
+      });
     return () => {
       cancelled = true;
     };
   }, []);
 
   const persist = useCallback((next: string[]): void => {
-    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next)).catch(() => {});
+    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next)).catch(
+      (error: unknown) => {
+        console.warn("[recent-searches] persist failed", error);
+      },
+    );
   }, []);
 
   const addRecentSearch = useCallback(

--- a/src/views/epigram-detail/ui/EpigramDetailScreen.tsx
+++ b/src/views/epigram-detail/ui/EpigramDetailScreen.tsx
@@ -1,3 +1,4 @@
+import { router } from "expo-router";
 import { type ReactElement } from "react";
 
 import { useEpigramDetail } from "~/entities/epigram";
@@ -17,7 +18,9 @@ export function EpigramDetailScreen({
 }: EpigramDetailScreenProps): ReactElement | null {
   const { user, isLoading: isMeLoading } = useMe();
   const { data: epigram } = useEpigramDetail(epigramId);
-  const { handleDelete, isDeleting } = useEpigramDelete(epigramId);
+  const { handleDelete, isDeleting } = useEpigramDelete(epigramId, {
+    onSuccess: () => router.replace("/feeds"),
+  });
 
   if (isMeLoading || !user) return <LoadingState />;
 


### PR DESCRIPTION
## Summary
views 와 widgets 사이 중간 계층인 **features 레이어 내부 중복을 정리하고 몇 가지 버그 수정**. 계층별 순차 리팩토링 2단계. 13개 파일 (신규 2 / 수정 11).

## 🆕 신규 공통 모듈

**[`features/epigram-create/model/resolveAuthor.ts`](src/features/epigram-create/model/resolveAuthor.ts)**
- `useEpigramCreate` / `useEpigramEdit` 각각 인라인으로 있던 `resolveAuthor`를 하나로 통합
- `userNickname` 전달 시 SELF 케이스에서 사용, 없으면 `values.authorName` → 최종 폴백 `"본인"`

**[`features/auth/model/useAuthMutation.ts`](src/features/auth/model/useAuthMutation.ts)**
- `LoginForm` / `SignUpForm` / `GuestLoginButton` 3곳에서 반복되던 `queryClient.setQueryData(userKeys.me(), user) + router.replace(target)` 패턴을 훅으로 추출
- `handleAuthSuccess(result, redirectTo?)` 단일 API

## 🔧 중복 제거 적용

- `useEpigramCreate` / `useEpigramEdit`: 인라인 `resolveAuthor` 제거, 공통 유틸 import
- `LoginForm` / `SignUpForm` / `GuestLoginButton`: `useQueryClient` / `router` / `userKeys` 직접 import 제거 → `handleAuthSuccess()` 호출로 대체

## 🐛 bug / policy 수정

- **`useLogout` race 수정** — `router.replace('/feeds')` → `await clearTokens()` → `queryClient.clear()` → `router.replace()` 순서로 변경. 이전엔 navigate가 먼저 실행되어 토큰 정리 전에 라우팅되는 race 가능성
- **`useEpigramDelete` 라우팅 분리** — `router.replace` 호출 제거하고 `onSuccess?: () => void` 옵션 콜백으로 위임. 삭제 성공 후 동작을 호출자가 결정. `EpigramDetailScreen`에서 `onSuccess: () => router.replace('/feeds')` 명시
- **`useRecentSearches` 에러 로깅** — AsyncStorage `.catch(() => {})` 두 곳 → `console.warn("[recent-searches] ...", error)` 로 최소 로깅. 저장/로딩 실패가 silent로 삼켜지던 문제

## ⚖️ 정책 유지

- Alert 2단계 확인 (ActionMenu 메뉴 → useEpigramDelete 확인) 그대로
- `useEpigramDelete`의 `onError` Alert는 hook 내부 유지 (호출자마다 에러 UI 재구현 방지)

## 🚫 이번 PR 범위 밖

- **EpigramForm 12-prop sprawl** → PR #3 widgets
- **Comment 3 feature 공통화** (CommentForm / CommentEditForm / useCommentCreate / useCommentEdit) → 별개 PR

## Test plan
- [ ] tsc 통과 (로컬 확인 완료)
- [ ] 로그인 / 회원가입 / 게스트 로그인 → feeds로 이동 확인
- [ ] 에피그램 작성 / 수정 (author SELF/DIRECT/UNKNOWN 각 케이스)
- [ ] 에피그램 삭제 → feeds로 이동 확인
- [ ] 로그아웃 → 토큰 정리 후 이동 확인
- [ ] 검색 최근 기록 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)