### PR TITLE
refactor: cross-cutting 공통화 — EmptyState 컴포넌트 + showActionAlert 유틸

### DIFF
--- a/src/shared/lib/showActionAlert.ts
+++ b/src/shared/lib/showActionAlert.ts
@@ -1,0 +1,26 @@
+import { Alert } from "react-native";
+
+export interface ActionAlertItem {
+  label: string;
+  onPress: () => void;
+  destructive?: boolean;
+}
+
+export function showActionAlert(
+  title: string,
+  actions: ActionAlertItem[],
+): void {
+  Alert.alert(
+    title,
+    undefined,
+    [
+      ...actions.map((action) => ({
+        text: action.label,
+        style: action.destructive ? ("destructive" as const) : undefined,
+        onPress: action.onPress,
+      })),
+      { text: "취소", style: "cancel" as const },
+    ],
+    { cancelable: true },
+  );
+}

--- a/src/shared/ui/EmptyState.tsx
+++ b/src/shared/ui/EmptyState.tsx
@@ -1,0 +1,51 @@
+import type { ReactElement, ReactNode } from "react";
+import { Text, View } from "react-native";
+
+import { cn } from "~/shared/lib/cn";
+
+interface EmptyStateProps {
+  title: string;
+  description?: string;
+  icon?: ReactNode;
+  variant?: "boxed" | "plain";
+  className?: string;
+}
+
+export function EmptyState({
+  title,
+  description,
+  icon,
+  variant = "plain",
+  className,
+}: EmptyStateProps): ReactElement {
+  const containerClass =
+    variant === "boxed"
+      ? "items-center gap-2 rounded-2xl border border-dashed border-line-200 px-4 py-10"
+      : "flex-1 items-center justify-center py-20";
+
+  return (
+    <View className={cn(containerClass, className)}>
+      {icon}
+      <Text
+        className={cn(
+          variant === "boxed"
+            ? "font-sans text-sm font-semibold text-black-700"
+            : "font-serif text-base text-black-300",
+        )}
+      >
+        {title}
+      </Text>
+      {description !== undefined && (
+        <Text
+          className={cn(
+            variant === "boxed"
+              ? "font-sans text-xs text-black-300"
+              : "mt-2 font-sans text-sm text-blue-400",
+          )}
+        >
+          {description}
+        </Text>
+      )}
+    </View>
+  );
+}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,5 +1,6 @@
 export { Button } from "./Button";
 export type { ButtonProps } from "./Button";
+export { EmptyState } from "./EmptyState";
 export { ErrorBoundary } from "./ErrorBoundary";
 export { ErrorState } from "./ErrorState";
 export { Input } from "./Input";

--- a/src/views/epigram-detail/ui/EpigramDetailActionMenu.tsx
+++ b/src/views/epigram-detail/ui/EpigramDetailActionMenu.tsx
@@ -1,7 +1,9 @@
 import { router } from "expo-router";
 import { MoreVertical } from "lucide-react-native";
 import type { ReactElement } from "react";
-import { Alert, Pressable } from "react-native";
+import { Pressable } from "react-native";
+
+import { showActionAlert } from "~/shared/lib/showActionAlert";
 
 interface EpigramDetailActionMenuProps {
   epigramId: number;
@@ -15,19 +17,13 @@ export function EpigramDetailActionMenu({
   isDeleting,
 }: EpigramDetailActionMenuProps): ReactElement {
   function handleOpenMenu(): void {
-    Alert.alert(
-      "에피그램",
-      undefined,
-      [
-        {
-          text: "수정",
-          onPress: () => router.push(`/epigrams/${epigramId}/edit`),
-        },
-        { text: "삭제", style: "destructive", onPress: onDelete },
-        { text: "취소", style: "cancel" },
-      ],
-      { cancelable: true },
-    );
+    showActionAlert("에피그램", [
+      {
+        label: "수정",
+        onPress: () => router.push(`/epigrams/${epigramId}/edit`),
+      },
+      { label: "삭제", destructive: true, onPress: onDelete },
+    ]);
   }
 
   return (

--- a/src/widgets/epigram-detail-list/ui/CommentItem.tsx
+++ b/src/widgets/epigram-detail-list/ui/CommentItem.tsx
@@ -1,11 +1,12 @@
 import { MoreVertical } from "lucide-react-native";
 import { memo, type ReactElement } from "react";
-import { Alert, Pressable, Text, View } from "react-native";
+import { Pressable, Text, View } from "react-native";
 
 import { type Comment } from "~/entities/comment";
 import { useCommentDelete } from "~/features/comment-delete";
 import { CommentEditForm } from "~/features/comment-edit";
 import { formatRelativeTime } from "~/shared/lib/date";
+import { showActionAlert } from "~/shared/lib/showActionAlert";
 import { UserAvatar } from "~/shared/ui";
 
 interface CommentItemProps {
@@ -34,16 +35,10 @@ function CommentItemBase({
     currentUserId !== undefined && comment.writer.id === currentUserId;
 
   function handleOpenMenu(): void {
-    Alert.alert(
-      "댓글",
-      undefined,
-      [
-        { text: "수정", onPress: () => onStartEdit(comment.id) },
-        { text: "삭제", style: "destructive", onPress: deleteComment },
-        { text: "취소", style: "cancel" },
-      ],
-      { cancelable: true },
-    );
+    showActionAlert("댓글", [
+      { label: "수정", onPress: () => onStartEdit(comment.id) },
+      { label: "삭제", destructive: true, onPress: deleteComment },
+    ]);
   }
 
   if (isEditing) {

--- a/src/widgets/epigram-detail-list/ui/EpigramDetailList.tsx
+++ b/src/widgets/epigram-detail-list/ui/EpigramDetailList.tsx
@@ -6,6 +6,7 @@ import { useEpigramComments, type Comment } from "~/entities/comment";
 import { useMe } from "~/entities/user";
 import { CommentForm } from "~/features/comment-create";
 import { useScrollToFocusedInput } from "~/shared/hooks/useScrollToFocusedInput";
+import { EmptyState } from "~/shared/ui";
 
 import { CommentItem } from "./CommentItem";
 
@@ -43,17 +44,14 @@ function CommentSkeleton(): ReactElement {
   );
 }
 
-function EmptyState(): ReactElement {
+function CommentsEmptyState(): ReactElement {
   return (
-    <View className="items-center gap-2 rounded-2xl border border-dashed border-line-200 px-4 py-10">
-      <MessageCircle size={28} color="#6a82a9" strokeWidth={1.5} />
-      <Text className="font-sans text-sm font-semibold text-black-700">
-        아직 댓글이 없어요
-      </Text>
-      <Text className="font-sans text-xs text-black-300">
-        첫 번째 댓글을 남겨보세요.
-      </Text>
-    </View>
+    <EmptyState
+      variant="boxed"
+      icon={<MessageCircle size={28} color="#6a82a9" strokeWidth={1.5} />}
+      title="아직 댓글이 없어요"
+      description="첫 번째 댓글을 남겨보세요."
+    />
   );
 }
 
@@ -156,7 +154,7 @@ export function EpigramDetailList({
     }
     return (
       <View className="pt-4">
-        <EmptyState />
+        <CommentsEmptyState />
       </View>
     );
   }, [isLoading]);

--- a/src/widgets/epigram-feed/ui/EpigramFeed.tsx
+++ b/src/widgets/epigram-feed/ui/EpigramFeed.tsx
@@ -16,7 +16,7 @@ import {
 } from "~/entities/epigram";
 import { useMe } from "~/entities/user";
 import { EmotionSelector } from "~/features/emotion-select";
-import { ErrorBoundary, SectionErrorFallback } from "~/shared/ui";
+import { EmptyState, ErrorBoundary, SectionErrorFallback } from "~/shared/ui";
 
 const FEED_PAGE_SIZE = 10;
 
@@ -92,16 +92,12 @@ function LoadingState(): ReactElement {
   );
 }
 
-function EmptyState(): ReactElement {
+function FeedEmptyState(): ReactElement {
   return (
-    <View className="flex-1 items-center justify-center py-20">
-      <Text className="font-serif text-base text-black-300">
-        등록된 에피그램이 없습니다
-      </Text>
-      <Text className="mt-2 font-sans text-sm text-blue-400">
-        첫 번째 에피그램을 작성해 보세요
-      </Text>
-    </View>
+    <EmptyState
+      title="등록된 에피그램이 없습니다"
+      description="첫 번째 에피그램을 작성해 보세요"
+    />
   );
 }
 
@@ -166,7 +162,7 @@ function EpigramFeedInner(): ReactElement {
       renderItem={renderItem}
       ItemSeparatorComponent={ItemSeparator}
       ListHeaderComponent={<ListHeader showEmotionSelector={isAuthenticated} />}
-      ListEmptyComponent={EmptyState}
+      ListEmptyComponent={FeedEmptyState}
       ListFooterComponent={<FooterLoader visible={isFetchingNextPage} />}
       onEndReached={handleEndReached}
       onEndReachedThreshold={0.3}


### PR DESCRIPTION
## Summary
계층별 순차 리팩토링 **마지막 단계(4/4)**. cascade 진단에서 나온 cross-cutting 후보들을 실익 기준으로 재평가 후 **2건만** 추출.

## 신규

**[`shared/ui/EmptyState.tsx`](src/shared/ui/EmptyState.tsx)**
- `icon` / `title` / `description` / `variant('plain' | 'boxed')` prop
- `plain`: `flex-1 items-center justify-center py-20`, 서브타이틀은 `text-blue-400`
- `boxed`: dashed border 카드, title/description `text-black`

**[`shared/lib/showActionAlert.ts`](src/shared/lib/showActionAlert.ts)**
- `Alert.alert(title, undefined, [...actions, {취소, cancel}], { cancelable: true })` 의 반복 패턴을 `showActionAlert(title, actions)` 호출 한 줄로 감쌈
- `ActionAlertItem { label, onPress, destructive? }` 인터페이스

## 적용

- **widgets/epigram-feed** — 로컬 `EmptyState` 제거 → 공통 `EmptyState(plain)`
- **widgets/epigram-detail-list** — 로컬 dashed card `EmptyState` 제거 → 공통 `EmptyState(boxed, icon=MessageCircle)`
- **views/epigram-detail/ui/EpigramDetailActionMenu** — `Alert.alert` 직접 호출 → `showActionAlert("에피그램", [수정, 삭제(destructive)])`
- **widgets/epigram-detail-list/ui/CommentItem** — 동일 패턴 → `showActionAlert("댓글", [수정, 삭제(destructive)])`

## 재평가 후 스킵 (premature abstraction)

- **TagChip**: 4개 사용처가 시각적/동작적으로 상당히 다름 (removable / pressable / plain serif / plain sans + highlight). variant prop 6+ 필요해 통합 이득보다 복잡도 비용이 큼
- **Comment 3 feature 공통화** (`CommentForm` vs `CommentEditForm`): avatar / border color / button set 차이로 분리가 오히려 명확. ~15 LOC 절감 대비 abstraction 비용 큼
- **mypage 리스트들의 한 줄 Text empty / search의 custom highlight empty**: 각자 사연 있고 통합해도 variant 폭발. 2곳(feed, detail-list)에서만 실익

## 전체 리팩토링 시리즈 완료

| PR | 내용 |
|---|---|
| #129 | ScreenLayout + useInfiniteListQuery 공통화 (-170 LOC) |
| #130 | views 레이어 SRP (-154 LOC) |
| #131 | features 레이어 SRP (mutation 공통화 + race 수정 + 에러 로깅) |
| #132 | widgets 레이어 SRP (EpigramForm 460 LOC 분리 등) |
| **#133** | **cross-cutting 공통화 (이 PR)** |

## Test plan
- [ ] tsc 통과 (로컬 확인 완료)
- [ ] 피드 empty 상태 렌더 (비로그인 또는 게시물 없을 때)
- [ ] 에피그램 상세 댓글 없을 때 empty 상태
- [ ] 에피그램 상세 메뉴 (수정/삭제/취소) + 댓글 메뉴 (수정/삭제/취소) 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)