### PR TITLE
fix: 에피그램 삭제 시 댓글 캐시 무효화 — prefix 대신 predicate

### DIFF
--- a/src/features/epigram-delete/model/useEpigramDelete.ts
+++ b/src/features/epigram-delete/model/useEpigramDelete.ts
@@ -1,7 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Alert } from "react-native";
 
-import { commentKeys } from "~/entities/comment";
 import { deleteEpigram, epigramKeys } from "~/entities/epigram";
 
 interface UseEpigramDeleteOptions {
@@ -23,7 +22,9 @@ export function useEpigramDelete(
     mutationFn: () => deleteEpigram(epigramId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: epigramKeys.all });
-      queryClient.invalidateQueries({ queryKey: commentKeys.all });
+      queryClient.invalidateQueries({
+        predicate: (query) => query.queryKey.includes("comments"),
+      });
       onSuccess?.();
     },
     onError: () => {


### PR DESCRIPTION
## Summary
- #134 에서 `invalidateQueries({ queryKey: commentKeys.all })`를 추가했지만 마이페이지 내 댓글 목록이 여전히 stale 상태로 남아있던 문제를 수정했어요.
- 근본 원인: `commentKeys.all`은 `["comments"]`인데, 실제 마이페이지 내 댓글 쿼리 키는 `["users", userId, "comments", ...]` 구조여서 React Query의 prefix 매칭이 되지 않았어요. 결과적으로 `recent`만 무효화되고 `byUser` / `byEpigram` 키는 그대로 남았습니다.
- `queryKey` prefix 대신 `predicate`로 queryKey 배열에 `"comments"`가 포함된 모든 쿼리를 무효화하도록 변경했어요.

## Test plan
- [ ] 내가 쓴 에피그램을 삭제한 뒤 마이페이지 **댓글 탭**에서 그 에피그램에 달린 내 댓글이 사라지는지 확인
- [ ] 에피그램 상세 화면의 댓글 목록도 refetch 되는지 확인
- [ ] 마이페이지 에피그램 목록이 갱신되는지 재확인 (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)