### PR TITLE
fix: AuthGate auth-only를 mount 시점만 체크하게 변경 (#136)

### DIFF
--- a/src/features/auth/ui/AuthGate.tsx
+++ b/src/features/auth/ui/AuthGate.tsx
@@ -1,6 +1,6 @@
 import { useIsFocused } from "@react-navigation/native";
 import { Redirect, usePathname } from "expo-router";
-import type { ReactElement, ReactNode } from "react";
+import { useRef, type ReactElement, type ReactNode } from "react";
 
 import { useMe } from "~/entities/user";
 import { LoadingState } from "~/shared/ui";
@@ -12,10 +12,20 @@ interface AuthGateProps {
   children: ReactNode;
 }
 
+// auth-only 화면이 살아있는 동안 user가 falsy → truthy로 바뀌어도
+// (= 이 화면에서 로그인하는 흐름) /feeds로 자동 리다이렉트하지 않는다.
+// 명시적 router.replace(target)와 race를 일으켜 사용자가 의도한 redirect 대신
+// /feeds로 튕기는 문제를 막기 위함. mount 시점에 이미 로그인 상태였던 경우만
+// /feeds로 보낸다.
 export function AuthGate({ mode, children }: AuthGateProps): ReactElement | null {
   const { user, isLoading } = useMe();
   const pathname = usePathname();
   const isFocused = useIsFocused();
+  const wasLoggedInOnMount = useRef<boolean | null>(null);
+
+  if (!isLoading && wasLoggedInOnMount.current === null) {
+    wasLoggedInOnMount.current = user !== null;
+  }
 
   if (isLoading) return <LoadingState />;
 
@@ -25,7 +35,7 @@ export function AuthGate({ mode, children }: AuthGateProps): ReactElement | null
     return <Redirect href={`/login?redirect=${redirectParam}`} />;
   }
 
-  if (mode === "auth-only" && user) {
+  if (mode === "auth-only" && user && wasLoggedInOnMount.current === true) {
     if (!isFocused) return null;
     return <Redirect href="/feeds" />;
   }


### PR DESCRIPTION
## ✏️ 작업 내용

비로그인 → 보호 경로 → /login → 로그인 후 원래 페이지로 이동해야 하는데 **간헐적으로 /feeds로 가버리는 문제** 수정.

### 원인

`/login` 화면이 `<AuthGate mode="auth-only">`로 감싸져 있어 useMe가 user를 반환하는 순간 `/feeds`로 자동 Redirect:

```tsx
if (mode === "auth-only" && user) {
  if (!isFocused) return null;
  return <Redirect href="/feeds" />;
}
```

`handleAuthSuccess`는 다음을 순차 실행:

```ts
queryClient.setQueryData(userKeys.me(), user);   // ① 캐시 sync 업데이트
router.replace(redirectTo ?? DEFAULT_REDIRECT);  // ② navigation 예약
```

①이 실행되면 React Query가 useMe 구독자 전부 재렌더 트리거 → /login의 AuthGate가 user truthy로 재렌더 → `<Redirect href="/feeds" />` 반환. 같은 tick에 ②의 router.replace(target)도 처리됨. **둘 중 어느 navigation이 먼저 적용되느냐**에 따라 결과가 비결정적.

`useIsFocused` 가드는 unmount 직전 한 번의 재렌더는 못 막음.

### 변경

AuthGate auth-only가 **mount 시점의 인증 상태**만 기준으로 redirect 여부를 결정하도록 변경. 화면이 살아있는 동안 user가 falsy → truthy로 바뀌어도 redirect 안 함 (그 케이스는 명시적 `handleAuthSuccess`가 처리).

```tsx
const wasLoggedInOnMount = useRef<boolean | null>(null);

// 첫 non-loading render에서 mount 시점 상태를 캡처
if (!isLoading && wasLoggedInOnMount.current === null) {
  wasLoggedInOnMount.current = user !== null;
}

if (mode === "auth-only" && user && wasLoggedInOnMount.current === true) {
  if (!isFocused) return null;
  return <Redirect href="/feeds" />;
}
```

ref 초기화를 useEffect 대신 render body에서 하는 이유: useEffect는 render 후에 실행되므로 첫 비로딩 render의 결정에 ref가 반영되지 않음. render body에서 초기화하면 같은 render 내에서 결정과 캡처가 동시에 이뤄져 off-by-one 없음 (useRef를 사용한 일회성 초기화의 표준 패턴).

### 동작

| 케이스 | mount 시 user | 결과 |
|---|---|---|
| 이미 로그인 상태로 /login URL 직접 진입 | truthy | `/feeds`로 Redirect (기존 동작 유지) |
| 비로그인 상태로 /login 진입 → 로그인 | null → user | `<Redirect>` 안 함, `router.replace(target)` 단독 처리 |
| protected 화면에 비로그인 진입 | null | `/login?redirect=...` (기존 동작 유지) |

## 🗨️ 논의 사항 (참고 사항)

- 더 근본적으로는 setQueryData + router.replace 호출 순서를 뒤집거나 setQueryData를 navigation 후로 미루는 것도 가능하지만, expo-router 내부 스케줄링에 의존하는 약한 해결이라 구조적으로 race 자체를 없애는 방향 선택
- protected 모드는 user가 null일 때만 동작하므로 setQueryData로 user가 채워지는 시점엔 화면이 떠나는 방향이라 race 무관 (변경 불필요)

## 기대효과

- 비로그인 → 보호 경로 카드 → 로그인 → 원래 상세 페이지로 결정적 이동
- 일반/게스트 로그인 양쪽 동일하게 안정화

Closes #136