### PR TITLE
fix: 게스트 로그인이 redirect 파라미터 무시하던 문제 (#138)

### DIFF
--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -6,6 +6,8 @@ export { useAuthMutation } from "./model/useAuthMutation";
 export { useLogout } from "./model/useLogout";
 export { useSessionExpiryRedirect } from "./model/useSessionExpiryRedirect";
 
+export { resolveRedirectTarget } from "./lib/resolveRedirectTarget";
+
 export { AuthBrandHeader } from "./ui/AuthBrandHeader";
 export { AuthGate } from "./ui/AuthGate";
 export { AuthToggleLink } from "./ui/AuthToggleLink";

--- a/src/features/auth/lib/resolveRedirectTarget.ts
+++ b/src/features/auth/lib/resolveRedirectTarget.ts
@@ -1,0 +1,15 @@
+import type { Href } from "expo-router";
+
+const DEFAULT_REDIRECT: Href = "/feeds";
+
+// open redirect 방지: 디코딩 후 절대 경로(`/`로 시작)만 허용한다.
+export function resolveRedirectTarget(redirect: string | undefined): Href {
+  if (!redirect) return DEFAULT_REDIRECT;
+  try {
+    const decoded = decodeURIComponent(redirect);
+    if (decoded.startsWith("/")) return decoded as Href;
+    return DEFAULT_REDIRECT;
+  } catch {
+    return DEFAULT_REDIRECT;
+  }
+}

--- a/src/features/auth/ui/GuestLoginButton.tsx
+++ b/src/features/auth/ui/GuestLoginButton.tsx
@@ -1,9 +1,11 @@
+import { useLocalSearchParams } from "expo-router";
 import { useState, type ReactElement } from "react";
 import { ActivityIndicator, Pressable, Text, View } from "react-native";
 
 import { signIn } from "~/entities/user";
 import { cn } from "~/shared/lib/cn";
 
+import { resolveRedirectTarget } from "../lib/resolveRedirectTarget";
 import { useAuthMutation } from "../model/useAuthMutation";
 
 const GUEST_CREDENTIALS = {
@@ -13,6 +15,7 @@ const GUEST_CREDENTIALS = {
 
 export function GuestLoginButton(): ReactElement {
   const { handleAuthSuccess } = useAuthMutation();
+  const { redirect } = useLocalSearchParams<{ redirect?: string }>();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -21,7 +24,7 @@ export function GuestLoginButton(): ReactElement {
     setError(null);
     try {
       const result = await signIn(GUEST_CREDENTIALS);
-      handleAuthSuccess(result);
+      handleAuthSuccess(result, resolveRedirectTarget(redirect));
     } catch {
       setError("게스트 로그인에 실패했습니다. 잠시 후 다시 시도해주세요.");
     } finally {

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useLocalSearchParams, type Href } from "expo-router";
+import { useLocalSearchParams } from "expo-router";
 import type { ReactElement } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { View } from "react-native";
@@ -7,22 +7,11 @@ import { View } from "react-native";
 import { signIn } from "~/entities/user";
 import { Button, Input } from "~/shared/ui";
 
+import { resolveRedirectTarget } from "../lib/resolveRedirectTarget";
 import { useAuthMutation } from "../model/useAuthMutation";
 import { loginSchema, type LoginFormValues } from "../model/loginSchema";
 
 const DEFAULT_VALUES: LoginFormValues = { email: "", password: "" };
-const DEFAULT_REDIRECT: Href = "/feeds";
-
-function resolveRedirectTarget(redirect: string | undefined): Href {
-  if (!redirect) return DEFAULT_REDIRECT;
-  try {
-    const decoded = decodeURIComponent(redirect);
-    if (decoded.startsWith("/")) return decoded as Href;
-    return DEFAULT_REDIRECT;
-  } catch {
-    return DEFAULT_REDIRECT;
-  }
-}
 
 export function LoginForm(): ReactElement {
   const { handleAuthSuccess } = useAuthMutation();


### PR DESCRIPTION
## ✏️ 작업 내용

#136 / #137 에서 AuthGate auth-only race를 잡았지만, 그건 일반 로그인(LoginForm) 케이스만 해결. **게스트 로그인 버튼**은 redirect 파라미터를 **읽지도 넘기지도 않아** 보호 경로에서 게스트 로그인하면 항상 `/feeds`로 가던 별도 버그가 남아 있었음.

### 변경

1. **`src/features/auth/lib/resolveRedirectTarget.ts` 신규 (FSD lib)**
   - `LoginForm`에 로컬 함수로 정의돼 있던 `resolveRedirectTarget` + `DEFAULT_REDIRECT`를 추출
   - open-redirect 방지: 디코딩 후 `/`로 시작하는 절대 경로만 허용

2. **`LoginForm.tsx`**
   - 로컬 정의 제거하고 추출된 헬퍼 import해서 사용 (동작 변경 없음)

3. **`GuestLoginButton.tsx`**
   - `useLocalSearchParams<{ redirect?: string }>` 추가
   - `handleAuthSuccess(result, resolveRedirectTarget(redirect))` 로 호출 (기존: 두 번째 인자 누락)

4. **`features/auth/index.ts`**
   - `resolveRedirectTarget` 퍼블릭 API로 노출

## 🗨️ 논의 사항 (참고 사항)

- LoginForm이 가지고 있던 동일 로직이 GuestLoginButton에도 필요해져서 lib 추출. 향후 SignUpForm에서도 redirect 받게 되면 그대로 재사용 가능
- AuthGate auth-only race는 #137 fix로 이미 해결됐고, 이 PR은 redirect 파라미터 전달의 누락만 보강

## 기대효과

- 비로그인 → 보호 경로 → /login → **게스트 로그인** → 원래 상세 페이지로 이동
- /login 직접 진입(redirect 없음)에서 게스트 로그인하면 `/feeds` (기존 동작 유지)
- 일반 로그인 영향 없음

Closes #138